### PR TITLE
fix(website): fix search input autofocus (Closes #187)

### DIFF
--- a/apps/website/src/components/DocPage/Search/SearchView.tsx
+++ b/apps/website/src/components/DocPage/Search/SearchView.tsx
@@ -88,6 +88,7 @@ export const SearchView: FC<{
   isOpen?: boolean;
 }> = ({ onClickLink = () => {}, isOpen = false }) => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchQuery = useSearchParams().get('search');
 
   const [results, setResults] = useState<DocMetadata[]>([]);
@@ -156,8 +157,13 @@ export const SearchView: FC<{
 
   useEffect(() => {
     if (isOpen) {
-      inputRef.current?.focus();
+      timeoutRef.current = setTimeout(() => inputRef.current?.focus(), 10);
     }
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
   }, [isOpen]);
 
   const isNoResult =


### PR DESCRIPTION
# Description

The reason `inputRef?.current.focus()` didn't work was probably because of the delay caused by the transition effect on the model, when `isOpen` state changes the `focus()` method is triggered before the input component fully display on the screen thus causing the issue.

Fixes #187

## Type of change

1. Introduced a small delay that ensures `inputRef?.current.focus()` is called after input fully display on screen.
