### PR TITLE
fix(website): remove unnecessary padding around avatar

### DIFF
--- a/apps/website/src/components/Navbar/index.tsx
+++ b/apps/website/src/components/Navbar/index.tsx
@@ -177,7 +177,9 @@ export const Navbar: FC = () => {
               className="group-hover/github:fill-text-opposite mr-1"
             />
           </Link>
-          <ProfileDropDown />
+          <div className="-m-1.5">
+            <ProfileDropDown />
+          </div>
         </>
       }
     />

--- a/apps/website/src/components/ProfileDropdown/ProfileDropDown/index.tsx
+++ b/apps/website/src/components/ProfileDropdown/ProfileDropDown/index.tsx
@@ -15,7 +15,7 @@ export const ProfileDropDown: FC<ProfileDropDownProps> = ({
   ...props
 }) => (
   <DropDown identifier={DROPDOWN_IDENTIFIER}>
-    <DropDown.Trigger identifier={DROPDOWN_IDENTIFIER}>
+    <DropDown.Trigger identifier={DROPDOWN_IDENTIFIER} size="icon-sm">
       <Avatar {...props} />
     </DropDown.Trigger>
     <DropDown.Panel


### PR DESCRIPTION
My solution to the unnecessary padding issue.
I kept some of the original button padding to maintain better accessibility when clicking the avatar, but offset it with an extra wrapper div to remove the visual extra space.


Desktop view:
<img width="491" height="173" alt="image" src="https://github.com/user-attachments/assets/c758ae1f-e648-4a30-b5b8-127e478b6bf5" />


Mobile view:
<img width="609" height="75" alt="image" src="https://github.com/user-attachments/assets/40d61ce8-b209-45b4-837d-3f001a3fda4d" />
