### PR TITLE
refactor(website): added auto focus to the input of the locale switcher

### DIFF
--- a/apps/website/src/components/LocaleSwitcher/LocaleSwitcher.tsx
+++ b/apps/website/src/components/LocaleSwitcher/LocaleSwitcher.tsx
@@ -10,7 +10,7 @@ import {
 } from '@intlayer/design-system';
 import { MoveVertical } from 'lucide-react';
 import { useIntlayer, useLocale, useLocaleCookie } from 'next-intlayer';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC, useRef } from 'react';
 import { useLocaleSearch } from './useLocaleSearch';
 
 export type LocaleSwitcherProps = {
@@ -39,18 +39,16 @@ export const LocaleSwitcher: FC<LocaleSwitcherProps> = ({
     availableLocales,
     locale
   );
-  const [openedByClick, setOpenedByClick] = useState(false);
 
   if (locale) {
     localeName = fullLocaleName ? getLocaleName(locale) : locale.toUpperCase();
   }
 
-  useEffect(() => {
-    if (openedByClick && inputRef.current) {
+  const handleFocusInput = () => {
+    if (inputRef.current) {
       inputRef.current.focus();
-      setOpenedByClick(false);
     }
-  }, [openedByClick]);
+  };
 
   return (
     <div
@@ -62,7 +60,7 @@ export const LocaleSwitcher: FC<LocaleSwitcherProps> = ({
           identifier={DROPDOWN_IDENTIFIER}
           size="sm"
           className="!px-0"
-          onClick={() => setOpenedByClick(true)}
+          onClick={handleFocusInput}
         >
           <div className="flex w-full items-center justify-between text-text">
             <div className="text-nowrap px-2 text-base">{localeName}</div>

--- a/apps/website/src/components/LocaleSwitcher/LocaleSwitcher.tsx
+++ b/apps/website/src/components/LocaleSwitcher/LocaleSwitcher.tsx
@@ -10,7 +10,7 @@ import {
 } from '@intlayer/design-system';
 import { MoveVertical } from 'lucide-react';
 import { useIntlayer, useLocale, useLocaleCookie } from 'next-intlayer';
-import { type FC, useRef } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 import { useLocaleSearch } from './useLocaleSearch';
 
 export type LocaleSwitcherProps = {
@@ -39,10 +39,18 @@ export const LocaleSwitcher: FC<LocaleSwitcherProps> = ({
     availableLocales,
     locale
   );
+  const [openedByClick, setOpenedByClick] = useState(false);
 
   if (locale) {
     localeName = fullLocaleName ? getLocaleName(locale) : locale.toUpperCase();
   }
+
+  useEffect(() => {
+    if (openedByClick && inputRef.current) {
+      inputRef.current.focus();
+      setOpenedByClick(false);
+    }
+  }, [openedByClick]);
 
   return (
     <div
@@ -54,6 +62,7 @@ export const LocaleSwitcher: FC<LocaleSwitcherProps> = ({
           identifier={DROPDOWN_IDENTIFIER}
           size="sm"
           className="!px-0"
+          onClick={() => setOpenedByClick(true)}
         >
           <div className="flex w-full items-center justify-between text-text">
             <div className="text-nowrap px-2 text-base">{localeName}</div>


### PR DESCRIPTION
## Description
This pull request improves the user experience of the `LocaleSwitcher` component by ensuring the locale search input is automatically focused when the dropdown is opened via a click. The changes introduce state management and an effect hook to handle this behavior.

## Changes Made
Enhancements to dropdown interaction and focus management:

* Added `openedByClick` state and an `onClick` handler to the dropdown trigger, enabling the component to detect when the dropdown is opened by user interaction.
* Introduced a `useEffect` that focuses the locale search input when the dropdown is opened by click, and resets the state afterward.
* Updated imports to include `useEffect` and `useState` for managing the new behavior.

## Linked Issue
This PR closes issue #190 

## Video 
[Screencast from 2025-10-07 21-02-08.webm](https://github.com/user-attachments/assets/8b61b478-4a05-4a48-a05f-2d0fe5ca7855)

@aymericzip 
Please review. If there are enhancements you would want me to make, tell me. Thanks.