### PR TITLE
fix(chokidar): clean up stale dictionaries on key changes

### DIFF
--- a/packages/@intlayer/chokidar/src/handleContentDeclarationFileChange.ts
+++ b/packages/@intlayer/chokidar/src/handleContentDeclarationFileChange.ts
@@ -1,5 +1,8 @@
+import { unlink } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { getAppLogger } from '@intlayer/config';
 import type { IntlayerConfig } from '@intlayer/types';
+import { getUnmergedDictionaries } from '@intlayer/unmerged-dictionaries-entry';
 import { buildDictionary } from './buildIntlayerDictionary/buildIntlayerDictionary';
 import { createDictionaryEntryPoint } from './createDictionaryEntryPoint/createDictionaryEntryPoint';
 import { getBuiltDictionariesPath } from './createDictionaryEntryPoint/getBuiltDictionariesPath';
@@ -19,9 +22,66 @@ export const handleContentDeclarationFileChange = async (
     isVerbose: true,
   });
 
-  const localeDictionaries = await loadLocalDictionaries(filePath, config);
+  // Load new dictionaries from the changed file
+  const newDictionaries = await loadLocalDictionaries(filePath, config);
 
-  const dictionariesOutput = await buildDictionary(localeDictionaries, config);
+  // Get all existing unmerged dictionaries
+  const allUnmergedDictionaries = getUnmergedDictionaries(config);
+
+  // Find and clean up old dictionaries from the same file with different keys
+  const oldKeysToDelete = new Set<string>();
+  const newFilePaths = new Set(newDictionaries.map((d) => d.filePath));
+  const newKeys = new Set(newDictionaries.map((d) => d.key));
+
+  for (const [key, dictionariesArray] of Object.entries(
+    allUnmergedDictionaries
+  )) {
+    // Skip if this is a new key we're about to write
+    if (newKeys.has(key)) continue;
+
+    // Check if any dictionary in this group came from the file we're updating
+    for (const dict of dictionariesArray) {
+      if (newFilePaths.has(dict.filePath)) {
+        oldKeysToDelete.add(key);
+        appLogger(
+          `Detected key change in ${formatPath(dict.filePath)}: "${key}" will be removed`,
+          { isVerbose: true }
+        );
+        break;
+      }
+    }
+  }
+
+  // Delete old dictionary files
+  for (const oldKey of oldKeysToDelete) {
+    try {
+      // Delete unmerged dictionary
+      const unmergedPath = resolve(
+        config.content.unmergedDictionariesDir,
+        `${oldKey}.json`
+      );
+      await unlink(unmergedPath).catch(() => {});
+
+      // Delete merged dictionary
+      const mergedPath = resolve(
+        config.content.dictionariesDir,
+        `${oldKey}.json`
+      );
+      await unlink(mergedPath).catch(() => {});
+
+      // Delete type file
+      const typePath = resolve(config.content.typesDir, `${oldKey}.ts`);
+      await unlink(typePath).catch(() => {});
+
+      appLogger(`Cleaned up old dictionary files for key: "${oldKey}"`, {
+        isVerbose: true,
+      });
+    } catch (error) {
+      // Ignore cleanup errors, they're not critical
+    }
+  }
+
+  const dictionariesOutput = await buildDictionary(newDictionaries, config);
   const updatedDictionariesPaths = Object.values(
     dictionariesOutput?.mergedDictionaries ?? {}
   ).map((dictionary) => dictionary.dictionaryPath);
@@ -33,22 +93,26 @@ export const handleContentDeclarationFileChange = async (
     isVerbose: true,
   });
 
-  if (
+  // Always rebuild entry point and module augmentation if keys were deleted
+  const needsFullRebuild =
+    oldKeysToDelete.size > 0 ||
     updatedDictionariesPaths.some(
       (updatedDictionaryPath) =>
         !allDictionariesPaths.includes(updatedDictionaryPath)
-    )
-  ) {
+    );
+
+  if (needsFullRebuild) {
     await createDictionaryEntryPoint(config);
 
-    appLogger('Dictionary list built', {
+    appLogger('Dictionary list rebuilt', {
       isVerbose: true,
     });
   }
 
-  createModuleAugmentation(config);
+  // Always regenerate module augmentation to update TypeScript registry
+  await createModuleAugmentation(config);
 
-  appLogger('Module augmentation built', {
+  appLogger('Module augmentation rebuilt', {
     isVerbose: true,
   });
 

--- a/packages/vite-intlayer/src/intlayerPlugin.ts
+++ b/packages/vite-intlayer/src/intlayerPlugin.ts
@@ -9,6 +9,17 @@ import {
 import type { PluginOption } from 'vite';
 import { intlayerPrune } from './intlayerPrunePlugin';
 
+export type IntlayerPluginOptions = GetConfigurationOptions & {
+  /**
+   * If true, wipes the entire .intlayer folder on dev server startup
+   * to guarantee a fresh build from source files. Useful when dealing
+   * with stale cache or key changes made while the server was offline.
+   *
+   * @default false
+   */
+  cleanOnStartup?: boolean;
+};
+
 /**
  * @deprecated Rename to intlayer instead
  *
@@ -22,9 +33,11 @@ import { intlayerPrune } from './intlayerPrunePlugin';
  * ```
  *  */
 export const intlayerPlugin = (
-  configOptions?: GetConfigurationOptions
+  configOptions?: IntlayerPluginOptions
 ): PluginOption => {
-  const intlayerConfig = getConfiguration(configOptions);
+  const { cleanOnStartup = false, ...intlayerConfigOptions } =
+    configOptions || {};
+  const intlayerConfig = getConfiguration(intlayerConfigOptions);
   const { watch: isWatchMode } = intlayerConfig.content;
   const { optimize } = intlayerConfig.build;
 
@@ -68,7 +81,10 @@ export const intlayerPlugin = (
 
       buildStart: async () => {
         // Code to run when Vite build starts
-        await prepareIntlayer(intlayerConfig);
+        await prepareIntlayer(intlayerConfig, {
+          clean: cleanOnStartup,
+          forceRun: cleanOnStartup,
+        });
       },
     },
   ];


### PR DESCRIPTION
## Problem

When a developer changes the `key` property in a `.content.ts` file (e.g., from `'landing-page'` to `'new-landing'`), Intlayer's file watcher rebuilds the new dictionary but leaves the old dictionary files in place. This causes:

- Runtime error: `Dictionary {old-key} not found`
- TypeScript errors: Key not in registry
- Orphaned files in `.intlayer/` folder

## Root Cause

`handleContentDeclarationFileChange` only processes the current file's content without checking if the same file previously exported a dictionary with a different key.

## Solution

### Incremental Fix (@intlayer/chokidar)

When a file changes:
1. Compare new dictionary keys with existing dictionaries from same file path
2. Detect key changes by matching `filePath` property
3. Delete old dictionary files (unmerged, merged, types)
4. Rebuild entry points and module augmentation

### Cold-Start Fix (vite-intlayer)

Add optional `cleanOnStartup` config:

```typescript
intlayer({
  cleanOnStartup: true // Default: false
})
```

When enabled, wipes `.intlayer/` folder on dev server start to guarantee fresh build from source files.

## Testing

Manually tested scenarios:
1. Change key in `.content.ts` during dev → old files cleaned automatically
2. Change key while server off, then restart with `cleanOnStartup: true` → clean rebuild
3. Multiple key changes in sequence → no orphaned files

## Breaking Changes

None. Both features are opt-in or automatic cleanup of invalid state.