### PR TITLE
feat(website): add background in doc page layout

### DIFF
--- a/apps/website/src/components/BlogPage/BlogPageLayout.tsx
+++ b/apps/website/src/components/BlogPage/BlogPageLayout.tsx
@@ -31,8 +31,8 @@ export const BlogPageLayout: FC<BlogPageLayoutProps> = ({
           className="relative m-auto mb-3 h-full w-auto max-w-6xl flex-1 grow rounded-xl bg-background px-4 pb-24 max-md:pl-16 md:px-10"
           id="content"
         >
-          <BackgroundLayout className="z-0" />
-          <div className="relative z-10 h-full w-full">
+          <BackgroundLayout className="max-md:-ml-16 md:-ml-10 z-0" />
+          <div className="relative z-1">
             <BlogBreadCrumb
               className="mt-12 ml-10"
               activeSections={activeSections}

--- a/apps/website/src/components/DocPage/DocPageLayout.tsx
+++ b/apps/website/src/components/DocPage/DocPageLayout.tsx
@@ -34,8 +34,8 @@ export const DocPageLayout: FC<DocPageLayoutProps> = ({
           className="relative m-auto mb-3 h-full w-auto max-w-6xl flex-1 grow rounded-xl bg-background px-4 pb-24 max-md:pl-16 md:px-10"
           id="content"
         >
-          <BackgroundLayout className="z-0" />
-          <div className="relative z-10 h-full w-full">
+          <BackgroundLayout className="max-md:-ml-16 md:-ml-10 z-0" />
+          <div className="relative z-1">
             {displayBreadCrumb && (
               <DocBreadCrumb
                 className="mt-12 ml-10"


### PR DESCRIPTION
My solution to issue #313.

I use the z-0 solution mentioned in the issue but with an additional div to the display elements to ensure interactivity.

I choose to keep the BackgroundLayout component as is, so functionality on the other pages works as before.