### PR TITLE
fix(@intlayer/chokidar): update shell property in spawn options to be based on isWin

### DIFF
--- a/packages/@intlayer/chokidar/src/utils/runParallel/index.ts
+++ b/packages/@intlayer/chokidar/src/utils/runParallel/index.ts
@@ -45,7 +45,7 @@ export const runParallel = (proc?: string | string[]): ParallelHandle => {
     cwd: process.cwd(),
     stdio: 'inherit' as const,
     env: childEnv,
-    shell: false,
+    shell: isWin,
   };
 
   // Spawn the child process


### PR DESCRIPTION
# Description

I updated `dev` command in `package.json` to `intlayer watch --with 'next dev'`, following the steps in intlayer's next.js configuration guide displayed under [Watch dictionaries changes on Turbopack](https://intlayer.org/doc/environment/nextjs#watch-dictionaries-changes-on-turbopack) section.

**Running yarn dev on a Windows OS shell, I get this error**
``` shell
$ intlayer watch --with 'next dev'
[intlayer]  Watching Intlayer content declarations
[runParallel] Failed to start: spawn 'next ENOENT
```

**After doing some research, I have found [this Stack Overflow answer](https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows):**

``` shell
const myChildProc = spawn('my-command', ['my', 'args'], {shell: process.platform == 'win32'})
``` 

**Solution**

I've updated `spawnOptions` in `runParallel` to consider `isWin` boolean in its options.

**Explanation**

I am not sure if it will fix the problem but I think it makes sense.

---

## System info

```
OS Name:                   Microsoft Windows 10 Home
OS Version:                10.0.19045 N/A Build 19045
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
System Manufacturer:       TOSHIBA
System Model:              SATELLITE L755
System Type:               x64-based PC
Processor(s):              1 Processor(s) Installed.
                           [01]: Intel64 Family 6 Model 42 Stepping 7 GenuineIntel ~2301 Mhz
BIOS Version:              INSYDE 1.90, 17.05.2011
Windows Directory:         C:\WINDOWS
System Directory:          C:\WINDOWS\system32
```