### PR TITLE
fix(react-native): add defaultLocale prop for react-native provider

### DIFF
--- a/packages/react-native-intlayer/src/intlayerProvider.tsx
+++ b/packages/react-native-intlayer/src/intlayerProvider.tsx
@@ -1,9 +1,19 @@
-import type { PropsWithChildren } from 'react';
-import { IntlayerProviderContent } from 'react-intlayer';
+import {
+  IntlayerProviderContent,
+  type IntlayerProviderProps as IntlayerProviderPropsBase,
+} from 'react-intlayer';
 import { intlayerPolyfill } from './intlayerPolyfill';
 
 intlayerPolyfill();
 
-export const IntlayerProvider = ({ children }: PropsWithChildren) => (
-  <IntlayerProviderContent>{children}</IntlayerProviderContent>
+type IntlayerProviderProps = Pick<
+  IntlayerProviderPropsBase,
+  'children' | 'defaultLocale'
+>;
+
+export const IntlayerProvider = ({
+  children,
+  ...props
+}: IntlayerProviderProps) => (
+  <IntlayerProviderContent {...props}>{children}</IntlayerProviderContent>
 );


### PR DESCRIPTION
IntlayerProvider from react-native-intlayer package does not accept `defaultLocale` prop thus it's not passed to the underlying react provider.

In this PR I'm picking `children` and `defaultLocale` from React Provider for React Native Provider. Not sure if the rest of the props are much relatable but it might be a good idea to pass all of them, WDYT?

### Context
I was following [this guide](https://intlayer.org/doc/environment/react-native-and-expo) to add IntlLayer to our mobile app and I could not get the translations working, until I saw defaultLocale is not even passed down by the provider so hope this change makes sense.