### PR TITLE
Added the baseURL option for OpenAI AI provider.

### DIFF
--- a/packages/@intlayer/ai/src/aiSdk.ts
+++ b/packages/@intlayer/ai/src/aiSdk.ts
@@ -46,17 +46,6 @@ export enum AIProvider {
   GEMINI = 'gemini',
 }
 
-export type OpenAIProviderOptions = { 
-  baseURL:string
-};
-
-// Add provider options here.
-
-export type ProviderOptionsMap = {
-  [AIProvider.OPENAI]: OpenAIProviderOptions; 
-};
-
-
 export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'none';
 
 /**
@@ -64,9 +53,9 @@ export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'none';
  */
 export type AIOptions = {
   provider?: AIProvider;
-  options?: Partial<ProviderOptionsMap>;
   model?: Model;
   temperature?: number;
+  baseURL?:string
   apiKey?: string;
   applicationContext?: string;
 };
@@ -159,31 +148,35 @@ const getLanguageModel = (
     case AIProvider.OPENAI: {
       return createOpenAI({
         apiKey,
-        baseURL: aiOptions?.options?.[AIProvider.OPENAI]?.baseURL || "https://api.openai.com/v1"
+        baseURL:aiOptions.baseURL
       })(selectedModel);
     }
 
     case AIProvider.ANTHROPIC: {
       return createAnthropic({
         apiKey,
+        baseURL:aiOptions.baseURL
       })(selectedModel);
     }
 
     case AIProvider.MISTRAL: {
       return createMistral({
         apiKey,
+        baseURL:aiOptions.baseURL
       })(selectedModel);
     }
 
     case AIProvider.DEEPSEEK: {
       return createDeepSeek({
         apiKey,
+        baseURL:aiOptions.baseURL
       })(selectedModel);
     }
 
     case AIProvider.GEMINI: {
       return createGoogleGenerativeAI({
         apiKey,
+        baseURL:aiOptions.baseURL
       })(selectedModel);
     }
 


### PR DESCRIPTION
Hey, 

This pull request adds a configurable `baseURL` parameter to support OpenAI-type APIs, a format used by many projects, whether self-hosted LLMs or third-party platforms like OpenRouter, Featherless, etc.

**But i haven't been able to test my code.** The codebase is huge, and it would take too long to build on my computer. So, I've only verified that the subpackage `/packages/@intlayer/ai` builds correctly and that my code seems to work theoretically. My implementation might also be confusing, as the key fields `api`, `temperature`, and `model` are also provider options, but I'm not counting them.