### PR TITLE
feat: add tool annotations for improved LLM tool understanding

### DIFF
--- a/packages/@intlayer/mcp/src/tools/cli.ts
+++ b/packages/@intlayer/mcp/src/tools/cli.ts
@@ -17,6 +17,7 @@ export const loadCLITools: LoadCLITools = async (server) => {
   server.registerTool(
     'intlayer-build',
     {
+      title: 'Build Dictionaries',
       description:
         'Build the dictionaries. List all content declarations files `.content.{ts,tsx,js,json,...}` to update the content callable using the `useIntlayer` hook.',
       inputSchema: {
@@ -26,6 +27,9 @@ export const loadCLITools: LoadCLITools = async (server) => {
         envFile: z.string().optional().describe('Environment file'),
         verbose: z.boolean().optional().describe('Verbose output'),
         prefix: z.string().optional().describe('Log prefix'),
+      },
+      annotations: {
+        destructiveHint: true,
       },
     },
     async ({ watch, baseDir, env, envFile, verbose, prefix }) => {
@@ -76,6 +80,7 @@ export const loadCLITools: LoadCLITools = async (server) => {
   server.registerTool(
     'intlayer-fill',
     {
+      title: 'Fill Translations',
       description:
         'Fill the dictionaries with missing translations / review translations using Intlayer servers',
       inputSchema: {
@@ -130,6 +135,9 @@ export const loadCLITools: LoadCLITools = async (server) => {
           .optional()
           .describe('AI options'),
       },
+      annotations: {
+        destructiveHint: true,
+      },
     },
     async (props) => {
       try {
@@ -176,6 +184,7 @@ export const loadCLITools: LoadCLITools = async (server) => {
   server.registerTool(
     'intlayer-push',
     {
+      title: 'Push Dictionaries',
       description: 'Push local dictionaries to the server',
       inputSchema: {
         deleteLocaleDictionary: z
@@ -201,6 +210,9 @@ export const loadCLITools: LoadCLITools = async (server) => {
           })
           .optional()
           .describe('Git options'),
+      },
+      annotations: {
+        destructiveHint: true,
       },
     },
     async (props) => {
@@ -248,6 +260,7 @@ export const loadCLITools: LoadCLITools = async (server) => {
   server.registerTool(
     'intlayer-pull',
     {
+      title: 'Pull Dictionaries',
       description: 'Pull dictionaries from the CMS',
       inputSchema: {
         dictionaries: z
@@ -258,6 +271,9 @@ export const loadCLITools: LoadCLITools = async (server) => {
           .string()
           .optional()
           .describe('Path to save new dictionaries'),
+      },
+      annotations: {
+        destructiveHint: true,
       },
     },
     async (props) => {
@@ -290,6 +306,7 @@ export const loadCLITools: LoadCLITools = async (server) => {
   server.registerTool(
     'intlayer-content-list',
     {
+      title: 'List Content Declarations',
       description:
         'List the content declaration (.content.{ts,tsx,js,json,...}) files present in the project. That files contain the multilingual content of the application and are used to build the dictionaries.',
       inputSchema: {
@@ -311,6 +328,9 @@ export const loadCLITools: LoadCLITools = async (server) => {
           })
           .optional()
           .describe('Configuration options'),
+      },
+      annotations: {
+        readOnlyHint: true,
       },
     },
     async (props) => {
@@ -342,6 +362,7 @@ export const loadCLITools: LoadCLITools = async (server) => {
   server.registerTool(
     'intlayer-content-test',
     {
+      title: 'Test Translations',
       description:
         'Test if there are missing translations in the content declaration files. That files contain the multilingual content of the application and are used to build the dictionaries.',
       inputSchema: {
@@ -363,6 +384,9 @@ export const loadCLITools: LoadCLITools = async (server) => {
           })
           .optional()
           .describe('Configuration options'),
+      },
+      annotations: {
+        readOnlyHint: true,
       },
     },
     async (props) => {
@@ -396,6 +420,7 @@ export const loadCLITools: LoadCLITools = async (server) => {
   server.registerTool(
     'intlayer-transform',
     {
+      title: 'Transform Component',
       description:
         'Transform an existing component to use Intlayer. Trigger this action to transform an existing component to be multilingual. If the component does not exist, create a normal React component including text in JSX, and then trigger this tool to transform it.',
       inputSchema: {
@@ -425,6 +450,9 @@ export const loadCLITools: LoadCLITools = async (server) => {
           })
           .optional()
           .describe('Configuration options'),
+      },
+      annotations: {
+        destructiveHint: true,
       },
     },
     async (props) => {

--- a/packages/@intlayer/mcp/src/tools/docs.ts
+++ b/packages/@intlayer/mcp/src/tools/docs.ts
@@ -16,9 +16,13 @@ export const loadDocsTools: LoadDocsTools = async (server) => {
   server.registerTool(
     'get-doc-list',
     {
+      title: 'Get Doc List',
       description:
         'Get the list of docs names and their metadata to get more details about what doc to retrieve',
       inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+      },
     },
     async () => {
       try {
@@ -47,10 +51,14 @@ export const loadDocsTools: LoadDocsTools = async (server) => {
   server.registerTool(
     'get-doc',
     {
+      title: 'Get Doc by Key',
       description:
         'Get a doc by his key. Example: `./docs/en/getting-started.md`. List all docs metadata first to get more details about what doc key to retrieve.',
       inputSchema: {
         docKey: z.enum(docsKeys as [string, ...string[]]),
+      },
+      annotations: {
+        readOnlyHint: true,
       },
     },
     async ({ docKey }) => {
@@ -72,6 +80,7 @@ export const loadDocsTools: LoadDocsTools = async (server) => {
   server.registerTool(
     'get-doc-by-slug',
     {
+      title: 'Get Doc by Slug',
       description:
         'Get an array of docs by their slugs. If not slug is provided, return all docs (1.2Mb). List all docs metadata first to get more details about what doc to retrieve.',
       inputSchema: {
@@ -87,6 +96,9 @@ export const loadDocsTools: LoadDocsTools = async (server) => {
           .describe(
             'Strict mode - only return docs that match all slugs, by excluding additional slugs'
           ),
+      },
+      annotations: {
+        readOnlyHint: true,
       },
     },
     async ({ slug, strict }) => {


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all tools in the `@intlayer/mcp` package to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

**CLI Tools (7 tools):**
- `intlayer-build` - `destructiveHint: true`, title: "Build Dictionaries"
- `intlayer-fill` - `destructiveHint: true`, title: "Fill Translations"
- `intlayer-push` - `destructiveHint: true`, title: "Push Dictionaries"
- `intlayer-pull` - `destructiveHint: true`, title: "Pull Dictionaries"
- `intlayer-content-list` - `readOnlyHint: true`, title: "List Content Declarations"
- `intlayer-content-test` - `readOnlyHint: true`, title: "Test Translations"
- `intlayer-transform` - `destructiveHint: true`, title: "Transform Component"

**Documentation Tools (3 tools):**
- `get-doc-list` - `readOnlyHint: true`, title: "Get Doc List"
- `get-doc` - `readOnlyHint: true`, title: "Get Doc by Key"
- `get-doc-by-slug` - `readOnlyHint: true`, title: "Get Doc by Slug"

## Why This Matters

- **Safety Automation**: MCP clients like Claude Code auto-approve tools with `readOnlyHint: true` without user confirmation, while destructive tools trigger confirmation prompts
- **UI/UX Improvements**: Clients can display appropriate warnings/icons based on `destructiveHint`
- **Tool Discovery**: `title` provides human-readable names for display in tool lists

## Testing

- [x] Server builds successfully (`bun run build` in `packages/@intlayer/mcp`)
- [x] Linter passes (`bun run lint`)
- [x] Verified annotations appear in built output (`dist/cjs/tools/*.cjs`)
- [x] Annotation values match actual tool behavior (read-only vs destructive)

## Before/After

**Before:**
```typescript
server.registerTool(
  'get-doc-list',
  {
    description: 'Get the list of docs names...',
    inputSchema: {},
  },
  async () => { ... }
);
```

**After:**
```typescript
server.registerTool(
  'get-doc-list',
  {
    title: 'Get Doc List',
    description: 'Get the list of docs names...',
    inputSchema: {},
    annotations: {
      readOnlyHint: true,
    },
  },
  async () => { ... }
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)