### PR TITLE
fix(website): correct Chinese translation for playground title

### DIFF
--- a/apps/website/src/app/[locale]/(playground)/playground/page.content.ts
+++ b/apps/website/src/app/[locale]/(playground)/playground/page.content.ts
@@ -11,7 +11,7 @@ const profileDashboardContent = {
       de: 'Intlayer-Editor - Playground',
       ja: 'Intlayer エディタ - プレイグラウンド',
       ko: 'Intlayer 편집기 - 플레이그라운드',
-      zh: 'Intlayer 编辑器 - 撸猫',
+      zh: 'Intlayer 编辑器 - 演练场',
       it: 'Editor Intlayer - Playground',
       pt: 'Editor Intlayer - Playground',
       hi: 'इन्टलैयार एडिटर - प्लेगन',


### PR DESCRIPTION
## Description

This PR fixes an incorrect Chinese translation for the "Playground" page title. The previous translation "撸猫" (which colloquially means "petting a cat") was incorrect in this context and has been updated to "演练场" (Playground/Drill ground) to better reflect the purpose of the page.

## Changes

- Updated `zh` translation in `apps/website/src/app/[locale]/(playground)/playground/page.content.ts`

## Checklist

- [x] Code follows the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] Verified the translation correctness.

# Pull Request Guidelines

Thank you for contributing to the project! Please make sure your pull request follows these guidelines before submission.

---

## Requirements

- **AI-generated code must be reviewed.**  
  Tips to identify AI-generated code:
  - Verbose or redundant JSDoc — make JSDoc synthetic and concise.
  - Abbreviations in variables or functions (e.g., `d` instead of `dictionary`) — avoid abbreviations.
  - Overly compact code — add line breaks and spacing to improve readability.

- **Tests and build must pass** before requesting a review.

- **Commits must follow the [Conventional Commit](https://www.conventionalcommits.org/) format.**

- **The [`CONTRIBUTING.md`](./CONTRIBUTING.md)** file must be read before submitting a PR.

---

## Codebase Conventions

- Prefer **arrow functions** (`() => {}`) over function declarations (`function () {}`).
- Prefer **TypeScript `type`** over `interface`.  
  Use `interface` only for **module augmentation**.
- For better testing and reusability, prefer **one function per file**.
- Prefer **`??`** over **`||`** syntax.
- Prefer **`import type`** over `import` for type imports.
- Prefer named exports over default exports.
- Avoid abbreviations in variable names:
  - `locale` instead of `loc`
  - `map(dictionary => dictionary.key)` instead of `map(d => d.key)`
