### PR TITLE
react-native-intlayer - Invalid Regex on Windows

### DIFF
--- a/packages/react-native-intlayer/src/exclusionList.ts
+++ b/packages/react-native-intlayer/src/exclusionList.ts
@@ -1,11 +1,14 @@
 import path from 'node:path';
 
-const escapeRegExp = (pattern: RegExp | string) => {
+const escapeRegExp = (pattern: RegExp | string): string => {
+  // Pre-compute separator to avoid template literal issues on Windows
+  const sep = path.sep === '\\' ? '\\\\' : '/';
+
   if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
-    return (pattern as RegExp).source.replace(/\/|\\\//g, `\\${path.sep}`);
+    return (pattern as RegExp).source.replace(/\//g, sep);
   } else if (typeof pattern === 'string') {
-    var escaped = pattern.replace(/[-[\]{}()*+?.\\^$|]/g, '\\$&');
-    return escaped.replaceAll('/', `\\${path.sep}`);
+    var escaped = pattern.replace(/[\-\[\]{}()*+?.\\^$|]/g, '\\$&');
+    return escaped.replace(/\//g, sep);
   } else {
     throw new Error(`Unexpected exclusion pattern: ${pattern}`);
   }


### PR DESCRIPTION

## Package Affected

`react-native-intlayer` v8.3.4

## Bug Summary

The `exclusionList` function in `exclusionList.ts` produces an invalid regex on Windows due to improper handling of `path.sep` in template literals.

When `path.sep` is `\` (backslash on Windows), the template literal `` `\\${path.sep}` `` evaluates to `\\`, creating an invalid regex pattern that causes:

```
SyntaxError: Invalid regular expression: /(\.expo[\\\]types|.../: Unterminated character class
```

This breaks Metro bundler config loading on Windows.

## Problematic Code

```typescript
// packages/react-native-intlayer/src/exclusionList.ts

const escapeRegExp = (pattern: RegExp | string) => {
  if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
    return (pattern as RegExp).source.replace(/\/|\\\//g, `\\${path.sep}`);
  } else if (typeof pattern === 'string') {
    var escaped = pattern.replace(/[\-\[\]{}()*+?.\\^$|]/g, '\\$&');
    return escaped.replaceAll('/', `\\${path.sep}`);  // <-- BUG
  }
  // ...
};
```

## Suggested Fix

```typescript
import path from 'node:path';

const escapeRegExp = (pattern: RegExp | string): string => {
  // Pre-compute separator to avoid template literal issues on Windows
  const sep = path.sep === '\\' ? '\\\\' : '/';
  
  if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
    return (pattern as RegExp).source.replace(/\//g, sep);
  } else if (typeof pattern === 'string') {
    var escaped = pattern.replace(/[\-\[\]{}()*+?.\\^$|]/g, '\\$&');
    return escaped.replace(/\//g, sep);
  } else {
    throw new Error(`Unexpected exclusion pattern: ${pattern}`);
  }
};

export const exclusionList = (additionalExclusions?: (RegExp | string)[]) =>
  new RegExp(`(${(additionalExclusions || []).map(escapeRegExp).join('|')})$`);
```
