### PR TITLE
fix(chokidar, cli): fix orphaned child processes on intlayer watch exit

### DIFF
--- a/packages/@intlayer/chokidar/src/utils/runParallel/index.ts
+++ b/packages/@intlayer/chokidar/src/utils/runParallel/index.ts
@@ -83,13 +83,10 @@ export const runParallel = (proc?: string | string[]): ParallelHandle => {
           `[runParallel] Failed to start: ${err?.message ?? String(err)}`
         );
       } catch {}
-      cleanupHandlers();
       reject(err);
     });
 
     child.on('exit', (code, signal) => {
-      cleanupHandlers();
-
       // Treat common termination signals as graceful exits, not failures
       const gracefulSignals = ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP'];
       // Also treat shell-convention exit codes (128 + signal number) as graceful:
@@ -108,33 +105,6 @@ export const runParallel = (proc?: string | string[]): ParallelHandle => {
       }
     });
   });
-
-  const cleanup = () => {
-    try {
-      child.kill('SIGTERM');
-    } catch {
-      // Best effort
-    }
-  };
-
-  const signalHandlers: { event: string; handler: (...args: any[]) => void }[] =
-    [
-      { event: 'SIGINT', handler: cleanup },
-      { event: 'SIGTERM', handler: cleanup },
-      { event: 'SIGQUIT', handler: cleanup },
-      { event: 'SIGHUP', handler: cleanup },
-    ];
-
-  // Register signal handlers
-  signalHandlers.forEach(({ event, handler }) => {
-    process.on(event as any, handler as any);
-  });
-
-  const cleanupHandlers = () => {
-    signalHandlers.forEach(({ event, handler }) => {
-      process.off(event as any, handler as any);
-    });
-  };
 
   const kill = () => {
     try {

--- a/packages/@intlayer/chokidar/src/utils/runParallel/spawnPosix.ts
+++ b/packages/@intlayer/chokidar/src/utils/runParallel/spawnPosix.ts
@@ -4,14 +4,15 @@
 
 import type { SpawnOptions } from 'node:child_process';
 import { type ChildProcess, spawn as nodeSpawn } from 'node:child_process';
-import { list } from './pidTree';
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
 /**
- * Kills the new process and its sub processes.
+ * Kills the new process and its sub processes synchronously using
+ * process group kill (negative PID). This ensures all descendants
+ * are terminated before the parent calls process.exit().
  */
 const createKillHandler = (
   child: ChildProcess
@@ -19,44 +20,22 @@ const createKillHandler = (
   return (signal?: NodeJS.Signals | number): boolean => {
     if (!child.pid) return false;
 
-    // Try using list if available
+    const killSignal = signal ?? 'SIGTERM';
+
+    // Use synchronous process group kill (negative PID) as primary strategy.
+    // This kills the entire process group (shell + all descendants) immediately.
     try {
-      list(child.pid, { root: true }, (err: Error | null, pids?: number[]) => {
-        if (err) {
-          // Fallback to process group kill
-          try {
-            process.kill(-child.pid!, signal ?? 'SIGTERM');
-          } catch {
-            // ignore
-          }
-          return;
-        }
-
-        if (!pids) {
-          // Fallback to process group kill if no pids returned
-          try {
-            process.kill(-child.pid!, signal ?? 'SIGTERM');
-          } catch {
-            // ignore
-          }
-          return;
-        }
-
-        for (const pid of pids) {
-          try {
-            process.kill(pid, signal ?? 'SIGTERM');
-          } catch (_err) {
-            // ignore.
-          }
-        }
-      });
+      process.kill(-child.pid, killSignal);
+      return true;
     } catch {
-      // pidtree not available, use process group kill
-      try {
-        process.kill(-child.pid, signal ?? 'SIGTERM');
-      } catch {
-        // ignore
-      }
+      // Process group kill failed (e.g., process not a group leader).
+    }
+
+    // Fallback: kill the child process directly.
+    try {
+      process.kill(child.pid, killSignal);
+    } catch {
+      // ignore — process may have already exited.
     }
 
     return true;
@@ -85,7 +64,9 @@ export const spawnPosix = (
   args: string[],
   options: SpawnOptions
 ): ChildProcess => {
-  const child = nodeSpawn(command, args, options);
+  // Spawn detached so the child becomes its own process group leader.
+  // This allows killing the entire tree via process.kill(-pid, signal).
+  const child = nodeSpawn(command, args, { ...options, detached: true });
   child.kill = createKillHandler(child);
 
   return child;

--- a/packages/@intlayer/cli/src/watch.ts
+++ b/packages/@intlayer/cli/src/watch.ts
@@ -42,23 +42,22 @@ export const watchContentDeclaration = async (options?: WatchOptions) => {
   });
 
   // Define a Graceful Shutdown function
+  let isShuttingDown = false;
   const handleShutdown = async () => {
     // Prevent multiple calls
-    process.off('SIGINT', handleShutdown);
-    process.off('SIGTERM', handleShutdown);
+    if (isShuttingDown) return;
+    isShuttingDown = true;
 
     appLogger('Stopping Intlayer watcher...');
 
     try {
-      // Close the file watcher immediately to stop "esbuild service not running" errors
-      await watcher.close();
-
-      // If runParallel exposes the child process, we can try to kill it explicitly.
-      // Even if it doesn't, process.exit() below usually cleans up attached children.
-      if (parallelProcess && 'child' in parallelProcess) {
-        // @ts-ignore - Assuming child exists on the return type if runParallel is based on spawn/exec
-        parallelProcess.child?.kill('SIGTERM');
+      // Kill the parallel process (e.g., Next.js) before closing the watcher
+      if (parallelProcess) {
+        parallelProcess.kill();
       }
+
+      // Close the file watcher to stop "esbuild service not running" errors
+      await watcher.close();
     } catch (error) {
       console.error('Error during shutdown:', error);
     } finally {


### PR DESCRIPTION
## Summary

When using `intlayer watch --with '...'`, Ctrl+C kills the intlayer watcher but leaves the child process (e.g. Next.js/Turbopack) running in the background.

Three issues:
- `watch.ts` checked `'child' in parallelProcess` to kill the child on shutdown, but `ParallelHandle` doesn't have a `child` property — so the kill never ran. Fixed to use `parallelProcess.kill()`.
- Child processes were spawned without `detached: true`, so `process.kill(-pid)` couldn't target the process group. Fixed in `spawnPosix`.
- `spawnPosix` used an async `pidtree` lookup to find descendant PIDs, but the parent called `process.exit()` before the callback fired. Replaced with synchronous process group kill.
- Removed duplicate signal handlers from `runParallel` since callers already handle shutdown.

## Test plan

- [x] `intlayer watch --with 'exec next dev --turbopack'` starts normally
- [x] Ctrl+C exits both intlayer and Next.js cleanly
- [x] No orphaned processes after exit