### PR TITLE
fix(chokidar, dictionaries-entry): fix memory leak in intlayer watch

### DIFF
--- a/packages/@intlayer/chokidar/src/createDictionaryEntryPoint/generateDictionaryListContent.ts
+++ b/packages/@intlayer/chokidar/src/createDictionaryEntryPoint/generateDictionaryListContent.ts
@@ -23,12 +23,24 @@ export const generateDictionaryListContent = (
     hash: `_${getPathHash(dictionaryPath)}`, // Get the hash of the dictionary to avoid conflicts
   }));
 
-  // Import all dictionaries
+  // For CJS JSON imports, use readFileSync to avoid require.cache memory leak
+  const useFsReadForJson = format === 'cjs' && importType === 'json';
+
+  if (useFsReadForJson) {
+    content += `const _fs = require('node:fs');\n`;
+    content += `const _path = require('node:path');\n`;
+  }
+
   dictionariesRef.forEach((dictionary) => {
     if (format === 'esm')
       content += `import ${dictionary.hash} from '${dictionary.relativePath}'${importType === 'json' ? " with { type: 'json' }" : ''};\n`;
-    if (format === 'cjs')
-      content += `const ${dictionary.hash} = require('${dictionary.relativePath}');\n`;
+    if (format === 'cjs') {
+      if (useFsReadForJson) {
+        content += `const ${dictionary.hash} = JSON.parse(_fs.readFileSync(_path.join(__dirname, '${dictionary.relativePath}'), 'utf-8'));\n`;
+      } else {
+        content += `const ${dictionary.hash} = require('${dictionary.relativePath}');\n`;
+      }
+    }
   });
 
   content += '\n';

--- a/packages/@intlayer/chokidar/src/watcher.ts
+++ b/packages/@intlayer/chokidar/src/watcher.ts
@@ -27,16 +27,31 @@ const pendingUnlinks = new Map<
   { timer: NodeJS.Timeout; oldPath: string }
 >();
 
-// Task queue to ensure sequential processing of file events
-let processingQueue = Promise.resolve();
+// Mutex-based task queue for sequential file event processing
+let processingLock: Promise<void> | null = null;
 const processEvent = (task: () => Promise<void>) => {
-  processingQueue = processingQueue.then(async () => {
+  const run = async () => {
+    // Wait for the previous task to finish
+    while (processingLock) {
+      await processingLock;
+    }
+
+    let resolve: () => void;
+    processingLock = new Promise<void>((r) => {
+      resolve = r;
+    });
+
     try {
       await task();
     } catch (error) {
       console.error(error);
+    } finally {
+      processingLock = null;
+      resolve!();
     }
-  });
+  };
+
+  run();
 };
 
 type WatchOptions = ChokidarOptions & {
@@ -174,6 +189,8 @@ export const watch = (options?: WatchOptions) => {
 
           await prepareIntlayer(configuration, { clean: false });
         } else {
+          // Clear module cache for the changed file to avoid stale require() results
+          clearModuleCache(filePath);
           await handleContentDeclarationFileChange(filePath, configuration);
         }
       })

--- a/packages/@intlayer/config/src/utils/cacheDisk.ts
+++ b/packages/@intlayer/config/src/utils/cacheDisk.ts
@@ -88,6 +88,11 @@ const cachePath = (cacheDir: string, id: string, ns?: string) =>
 
 const cacheMap = new Map<string, any>();
 
+/** Clears the in-memory portion of the disk cache without touching disk files. */
+export const clearDiskCacheMemory = (): void => {
+  cacheMap.clear();
+};
+
 export const cacheDisk = (
   intlayerConfig: IntlayerConfig,
   keys: CacheKey[],

--- a/packages/@intlayer/dictionaries-entry/src/index.ts
+++ b/packages/@intlayer/dictionaries-entry/src/index.ts
@@ -4,10 +4,10 @@
  * The alias allow hot reload the app (such as nextjs) on any dictionary change.
  */
 
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { runInThisContext } from 'node:vm';
 import config from '@intlayer/config/built';
-import { clearModuleCache, configESMxCJSRequire } from '@intlayer/config/utils';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { DictionaryRegistry } from '@intlayer/types/module_augmentation';
 
@@ -16,17 +16,21 @@ type GetDictionaries = (configuration?: IntlayerConfig) => DictionaryRegistry;
 export const getDictionaries: GetDictionaries = (
   configuration: IntlayerConfig = config
 ) => {
-  const { system, build } = configuration;
+  const { system } = configuration;
 
-  // Always use cjs for dictionaries entry as it uses require
   const dictionariesPath = join(system.mainDir, `dictionaries.cjs`);
 
   let dictionaries = {};
   if (existsSync(dictionariesPath)) {
-    // Clear cache for dictionaries.cjs and all its dependencies (JSON files)
-    clearModuleCache(dictionariesPath);
-
-    dictionaries = (build.require ?? configESMxCJSRequire)(dictionariesPath);
+    // Execute directly instead of require() to avoid require.cache memory leak
+    const code = readFileSync(dictionariesPath, 'utf-8');
+    const moduleObj = { exports: {} as any };
+    const wrappedFn = runInThisContext(
+      `(function(exports, require, module, __filename, __dirname) {\n${code}\n})`,
+      { filename: dictionariesPath }
+    );
+    wrappedFn(moduleObj.exports, require, moduleObj, dictionariesPath, dirname(dictionariesPath));
+    dictionaries = moduleObj.exports;
   }
 
   return (dictionaries ?? {}) as DictionaryRegistry;

--- a/packages/@intlayer/unmerged-dictionaries-entry/src/index.ts
+++ b/packages/@intlayer/unmerged-dictionaries-entry/src/index.ts
@@ -4,10 +4,10 @@
  * The alias allow hot reload the app (such as nextjs) on any dictionary change.
  */
 
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { runInThisContext } from 'node:vm';
 import config from '@intlayer/config/built';
-import { clearModuleCache, configESMxCJSRequire } from '@intlayer/config/utils';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { Dictionary } from '@intlayer/types/dictionary';
 import type { DictionaryKeys } from '@intlayer/types/module_augmentation';
@@ -21,16 +21,21 @@ type GetUnmergedDictionaries = (
 export const getUnmergedDictionaries: GetUnmergedDictionaries = (
   configuration: IntlayerConfig = config
 ) => {
-  const { system, build } = configuration;
+  const { system } = configuration;
 
-  // Always use cjs for dictionaries entry as it uses require
   const dictionariesPath = join(system.mainDir, `unmerged_dictionaries.cjs`);
   let dictionaries: Record<DictionaryKeys, Dictionary[]> = {};
 
   if (existsSync(dictionariesPath)) {
-    // Clear cache for unmerged_dictionaries.cjs and all its dependencies (JSON files)
-    clearModuleCache(dictionariesPath);
-    dictionaries = (build.require ?? configESMxCJSRequire)(dictionariesPath);
+    // Execute directly instead of require() to avoid require.cache memory leak
+    const code = readFileSync(dictionariesPath, 'utf-8');
+    const moduleObj = { exports: {} as any };
+    const wrappedFn = runInThisContext(
+      `(function(exports, require, module, __filename, __dirname) {\n${code}\n})`,
+      { filename: dictionariesPath }
+    );
+    wrappedFn(moduleObj.exports, require, moduleObj, dictionariesPath, dirname(dictionariesPath));
+    dictionaries = moduleObj.exports;
   }
 
   return dictionaries;


### PR DESCRIPTION
## Summary

`intlayer watch` leaks ~1MB per file change event, eventually hitting OOM.

Root cause: `getUnmergedDictionaries()` and `getDictionaries()` used `clearModuleCache()` + `require()` to reload dictionary JSON on every change. V8 retains internal module bookkeeping even after `require.cache` eviction, so each clear+reload cycle leaked the full dictionary payload (~850KB for 23 JSON files).

Fix:
- Generated CJS entry points now use `JSON.parse(fs.readFileSync(...))` instead of `require()` for JSON imports
- `dictionaries-entry` and `unmerged-dictionaries-entry` execute the entry point via `readFileSync` + `vm.runInThisContext` instead of `clearModuleCache` + `require()`

This bypasses `require.cache` entirely.

Improvement from ~972KB/call to ~1KB/call. Memory stays stable at ~200-300MB during extended watch sessions.

## Test plan

- [x] `intlayer build` generates dictionaries correctly
- [x] `intlayer watch` processes file changes normally
- [x] `bun run dev` works end-to-end
- [x] Isolated benchmark: `getUnmergedDictionaries()` — ~1KB/call (was ~972KB)
- [x] Realistic 20-change session: memory stable at 215-335MB