### PR TITLE
fix(chokidar): read dictionaries from disk to avoid require.cache leak

### DIFF
--- a/packages/@intlayer/chokidar/src/build.ts
+++ b/packages/@intlayer/chokidar/src/build.ts
@@ -5,5 +5,6 @@ export * from './createType/index';
 export * from './formatDictionary';
 export * from './loadDictionaries/index';
 export * from './prepareIntlayer';
+export * from './utils/readDictionariesFromDisk';
 export * from './writeConfiguration/index';
 export * from './writeContentDeclaration/index';

--- a/packages/@intlayer/chokidar/src/buildIntlayerDictionary/buildIntlayerDictionary.ts
+++ b/packages/@intlayer/chokidar/src/buildIntlayerDictionary/buildIntlayerDictionary.ts
@@ -1,7 +1,7 @@
 import { IMPORT_MODE, OUTPUT_FORMAT } from '@intlayer/config/defaultValues';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { Dictionary } from '@intlayer/types/dictionary';
-import { getUnmergedDictionaries } from '@intlayer/unmerged-dictionaries-entry';
+import { readDictionariesFromDisk } from '../utils/readDictionariesFromDisk';
 import {
   type LocalizedDictionaryOutput,
   writeDynamicDictionary,
@@ -46,7 +46,7 @@ export const buildDictionary = async (
 
   if (importOtherDictionaries) {
     const prevUnmergedDictionaries: Record<string, Dictionary[]> =
-      getUnmergedDictionaries(configuration);
+      readDictionariesFromDisk(configuration.system.unmergedDictionariesDir);
 
     // Reinsert other dictionaries with the same key to avoid merging errors
     for (const dictionaryToWrite of localDictionariesEntries) {

--- a/packages/@intlayer/chokidar/src/cleanRemovedContentDeclaration.ts
+++ b/packages/@intlayer/chokidar/src/cleanRemovedContentDeclaration.ts
@@ -6,12 +6,11 @@ import {
   colorizePath,
   getAppLogger,
 } from '@intlayer/config/logger';
-import { getDictionaries } from '@intlayer/dictionaries-entry';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { Dictionary } from '@intlayer/types/dictionary';
-import { getUnmergedDictionaries } from '@intlayer/unmerged-dictionaries-entry';
 import fg from 'fast-glob';
 import { createDictionaryEntryPoint } from './createDictionaryEntryPoint';
+import { readDictionariesFromDisk } from './utils/readDictionariesFromDisk';
 import { writeJsonIfChanged } from './writeJsonIfChanged';
 
 export const cleanRemovedContentDeclaration = async (
@@ -25,7 +24,9 @@ export const cleanRemovedContentDeclaration = async (
 }> => {
   const appLogger = getAppLogger(configuration);
 
-  const unmergedDictionaries = getUnmergedDictionaries(configuration);
+  const unmergedDictionaries = readDictionariesFromDisk<
+    Record<string, Dictionary[]>
+  >(configuration.system.unmergedDictionariesDir);
 
   const baseDir = configuration.system.baseDir;
 
@@ -88,7 +89,9 @@ export const cleanRemovedContentDeclaration = async (
     })
   );
 
-  const dictionaries = getDictionaries(configuration);
+  const dictionaries = readDictionariesFromDisk<Record<string, Dictionary>>(
+    configuration.system.dictionariesDir
+  );
   const flatDictionaries = Object.values(dictionaries) as Dictionary[];
 
   const filteredMergedDictionaries = flatDictionaries?.filter(

--- a/packages/@intlayer/chokidar/src/utils/readDictionariesFromDisk.ts
+++ b/packages/@intlayer/chokidar/src/utils/readDictionariesFromDisk.ts
@@ -1,0 +1,27 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, extname, join } from 'node:path';
+
+/**
+ * Reads all JSON dictionary files from a directory, keyed by filename.
+ * Uses readFileSync instead of require() to avoid require.cache memory leak.
+ */
+export const readDictionariesFromDisk = <T = Record<string, any>>(
+  directory: string
+): T => {
+  const dictionaries: Record<string, any> = {};
+
+  if (existsSync(directory)) {
+    const files = readdirSync(directory).filter((file) =>
+      file.endsWith('.json')
+    );
+
+    for (const file of files) {
+      const key = basename(file, extname(file));
+      dictionaries[key] = JSON.parse(
+        readFileSync(join(directory, file), 'utf-8')
+      );
+    }
+  }
+
+  return dictionaries as T;
+};

--- a/packages/@intlayer/chokidar/src/writeContentDeclaration/writeContentDeclaration.ts
+++ b/packages/@intlayer/chokidar/src/writeContentDeclaration/writeContentDeclaration.ts
@@ -12,12 +12,12 @@ import type { Locale } from '@intlayer/types/allLocales';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { Dictionary } from '@intlayer/types/dictionary';
 import type { LocalesValues } from '@intlayer/types/module_augmentation';
-import { getUnmergedDictionaries } from '@intlayer/unmerged-dictionaries-entry';
 import { detectFormatCommand } from '../detectFormatCommand';
 import {
   type Extension,
   getFormatFromExtension,
 } from '../utils/getFormatFromExtension';
+import { readDictionariesFromDisk } from '../utils/readDictionariesFromDisk';
 import type { DictionaryStatus } from './dictionaryStatus';
 import { processContentDeclarationContent } from './processContentDeclarationContent';
 import { transformJSONFile } from './transformJSONFile';
@@ -142,7 +142,9 @@ export const writeContentDeclaration = async (
 
   const newDictionaryLocationPath = join(baseDir, newDictionariesPath);
 
-  const unmergedDictionariesRecord = getUnmergedDictionaries(configuration);
+  const unmergedDictionariesRecord = readDictionariesFromDisk<
+    Record<string, Dictionary[]>
+  >(configuration.system.unmergedDictionariesDir);
   const unmergedDictionaries = unmergedDictionariesRecord[
     dictionary.key
   ] as Dictionary[];


### PR DESCRIPTION
## Summary

`buildIntlayerDictionary.ts`, `cleanRemovedContentDeclaration.ts`, and `writeContentDeclaration.ts` call `getUnmergedDictionaries()`/`getDictionaries()` on every file change, going through `require()` which leaks ~1MB/call due to V8 retaining internal module bookkeeping after cache eviction.

Adds a `readDictionariesFromDisk` utility in `@intlayer/chokidar` that reads JSON files directly via `readFileSync`. Entry packages are untouched.

Also exports `readDictionariesFromDisk` from `@intlayer/chokidar/build` in case the editor server needs it.

Improvement from ~972KB/call to ~18KB/call.

## Test plan

- [x] All packages build (42/42)
- [x] vite-react-app
- [x] vite-preact-app
- [x] vite-vue-app
- [x] vite-svelte-app
- [x] vite-solid-app
- [x] nextjs-15-app
- [x] Memory leak benchmark: ~18KB/call (was ~972KB)