### PR TITLE
fix(website): change the direction of the contributor avatar to right based on locale

### DIFF
--- a/apps/website/src/components/LandingPage/ContributorSection/ContributorCloud.tsx
+++ b/apps/website/src/components/LandingPage/ContributorSection/ContributorCloud.tsx
@@ -11,8 +11,9 @@ import {
 import { DiscordLogo } from '@intlayer/design-system/social-networks';
 import { cn } from '@intlayer/design-system/utils';
 import { motion } from 'framer-motion';
+import { getHTMLTextDir } from 'intlayer';
 import { ArrowRight } from 'lucide-react';
-import { useIntlayer } from 'next-intlayer';
+import { useIntlayer, useLocale } from 'next-intlayer';
 import {
   type CSSProperties,
   type FC,
@@ -171,14 +172,14 @@ const ContributorAvatar: FC<ContributorAvatarProps> = ({
 };
 
 // ... [Keep generateCloudPositions] ...
-const generateCloudPositions = (count: number) => {
+const generateCloudPositions = (count: number, isRTL = false) => {
   const positions = [];
   const goldenAngle = Math.PI * (3 - Math.sqrt(5));
   const maxRadiusX = 20;
   const maxRadiusY = 30;
   const cX = count > 1 ? maxRadiusX / Math.sqrt(count - 1) : 0;
   const cY = count > 1 ? maxRadiusY / Math.sqrt(count - 1) : 0;
-  const centerX = 25;
+  const centerX = isRTL ? 75 : 25;
   const centerY = 40;
 
   for (let i = 0; i < count; i++) {
@@ -198,7 +199,9 @@ export const ContributorCloud: FC<ContributorCloudProps> = ({
   const { discordLinkLabel, seeAllLink, title, subtitle } = useIntlayer(
     'contributor-section'
   );
-  const positions = generateCloudPositions(contributors.length);
+  const { locale } = useLocale();
+  const isRTL = getHTMLTextDir(locale) === 'rtl';
+  const positions = generateCloudPositions(contributors.length, isRTL);
   const sectionRef = useRef<HTMLElement>(null);
 
   // State to track the exact pixel size of the container


### PR DESCRIPTION
### Description
This pull request updates the contributor cloud component to better support right-to-left (RTL) languages. The main improvement is adjusting the layout of contributor avatars based on the text direction of the current locale.

### Changes Made
**Internationalization and RTL support:**

* Added `getHTMLTextDir` and `useLocale` imports to determine the current locale's text direction, enabling dynamic RTL/LTR layout adjustments.
* Modified `generateCloudPositions` to accept an `isRTL` parameter and updated the logic so that the cloud's center shifts appropriately for RTL languages.
* Updated the main `ContributorCloud` component to use the current locale and pass the correct `isRTL` value to `generateCloudPositions`, ensuring the avatar cloud layout matches the reading direction.

### Linked Issue
This PR closes issue #404 

### Screenshot
<img width="1755" height="667" alt="image" src="https://github.com/user-attachments/assets/54aa6613-b209-43e4-8976-4dec959f15fb" />

@aymericzip 
Please review, if there are improvements to make, tell me. Thanks.