### PR TITLE
fix(chokidar): intlayer build hangs when content.watch is true

### DIFF
--- a/packages/@intlayer/chokidar/src/watcher.ts
+++ b/packages/@intlayer/chokidar/src/watcher.ts
@@ -335,7 +335,12 @@ export const buildAndWatchIntlayer = async (options?: WatchOptions) => {
     await prepareIntlayer(configuration, { forceRun: true });
   }
 
-  if (configuration.content.watch || options?.persistent) {
+  // Only enter watch mode when the caller explicitly opts in via `persistent`.
+  // `configuration.content.watch` is the dev-mode signal consumed by bundler
+  // plugins (e.g. vite-intlayer's `configureServer`); it must not coerce
+  // `intlayer build` (which passes `persistent: false`) into a persistent
+  // watcher, since that prevents the build command from ever exiting.
+  if (options?.persistent) {
     await watch({ ...rest, configuration });
   }
 };


### PR DESCRIPTION
## Summary

`intlayer build` (and anything that runs it transitively — `prebuild`, `pretypecheck`, CI pipelines) hangs forever when `content.watch: true` is set in the user's `intlayer.config.ts`. The build never exits because the chokidar watcher is started with `persistent: true`, even though the CLI was not asked to watch.

The fault is a single line in `buildAndWatchIntlayer`:

```ts
// packages/@intlayer/chokidar/src/watcher.ts
if (configuration.content.watch || options?.persistent) {
  await watch({ ...rest, configuration });
}
```

`intlayer build` calls `buildAndWatchIntlayer({ persistent: options?.watch ?? false })`, so `persistent` is `false` for a normal build. But the **OR** allows `configuration.content.watch` to coerce the build into a persistent watcher.

This trips users who follow the documented pattern of enabling `content.watch: true` so that the `vite-intlayer` plugin (and other bundler plugins) get hot reload for content declarations during dev. The same config flag then poisons every non-dev invocation of the CLI.

## Reproduction

```bash
# intlayer.config.ts
export default {
  content: { watch: true, contentDir: ['src/locales'] },
} satisfies IntlayerConfig;

# any of these now hang on "Watching Intlayer content declarations":
pnpm intlayer build
pnpm prepare:content   # → calls intlayer build
pnpm build             # → prebuild → prepare:content
pnpm typecheck         # → pretypecheck → prepare:content
```

The hang appears after `Dictionaries built (xxms)` and never returns.

## Fix

Decouple the two signals. `options.persistent` is the *only* trigger for entering watch mode in `buildAndWatchIntlayer`; `configuration.content.watch` keeps its role as the dev-mode opt-in consumed by bundler plugins.

```ts
if (options?.persistent) {
  await watch({ ...rest, configuration });
}
```

## Why this is safe

- **`vite-intlayer` plugin** — `packages/vite-intlayer/src/intlayerPlugin.ts` calls `watch({ configuration })` *directly*, not via `buildAndWatchIntlayer`. Its dev-mode watching is unaffected.
- **`intlayer watch` CLI** — `packages/@intlayer/cli/src/watch.ts` calls `watch({ persistent: true, ... })` directly. Unaffected.
- **`intlayer build`** without `--watch` — now exits cleanly. ✓
- **`intlayer build --watch`** — passes `persistent: true`, still enters watch. ✓
- The existing guard inside `watch()` (`if (!configuration.content.watch) return;`) is unchanged, so users who explicitly disabled watching in config still get no-op behavior — preserving the prior surprise-minimizing contract.

## Test plan

- [ ] In a project with `content.watch: true` in config, run `intlayer build` — verify it exits with code 0.
- [ ] In the same project, run `intlayer build --watch` — verify it enters watch mode.
- [ ] In the same project, run `intlayer watch` — verify it enters watch mode.
- [ ] `vite dev` with `vite-intlayer` plugin — verify content HMR still works.