### PR TITLE
fix: update core package.json with default field configuration for "./file"

### DIFF
--- a/packages/@intlayer/core/package.json
+++ b/packages/@intlayer/core/package.json
@@ -91,6 +91,10 @@
       "browser": {
         "require": "./dist/cjs/transpiler/file/fileBrowser.cjs",
         "import": "./dist/esm/transpiler/file/fileBrowser.mjs"
+      },
+      "default": {
+        "require": "./dist/cjs/transpiler/file/fileBrowser.cjs",
+        "import": "./dist/esm/transpiler/file/fileBrowser.mjs"
       }
     },
     "./file/browser": {

--- a/packages/@intlayer/core/package.json
+++ b/packages/@intlayer/core/package.json
@@ -93,8 +93,8 @@
         "import": "./dist/esm/transpiler/file/fileBrowser.mjs"
       },
       "default": {
-        "require": "./dist/cjs/transpiler/file/fileBrowser.cjs",
-        "import": "./dist/esm/transpiler/file/fileBrowser.mjs"
+        "require": "./dist/cjs/transpiler/file/file.cjs",
+        "import": "./dist/esm/transpiler/file/file.mjs"
       }
     },
     "./file/browser": {


### PR DESCRIPTION
## Summary

Added default configuration for "./file" in intlayer's core package.json so that the exports are properly built on unexpected environments.

## Description

Building a project with vite and intlayer to deploy on Cloudflare's Workers raises the error:

```
  "./file" is not exported under the conditions ["workerd", "worker", "production", "wasm", "unwasm", "import"] from package /node_modules/@intlayer/core (see exports field in /node_modules/@intlayer/core/package.json)
```

## Fix

Add a default export config so that the build can proceed with minimum requirements.

```
       "browser": {
         "require": "./dist/cjs/transpiler/file/fileBrowser.cjs",
         "import": "./dist/esm/transpiler/file/fileBrowser.mjs"
+      },
+      "default": {
+        "require": "./dist/cjs/transpiler/file/file.cjs",
+        "import": "./dist/esm/transpiler/file/file.mjs"
       }
     },
     "./file/browser": {
```

## Test plan

- [x] `vite build` with `rolldown-vite` plugin (included by default) — verify build successfully for Cloudflare's configurations.