### PR TITLE
feat(core): add maxAge cookie storage attribute

### DIFF
--- a/docs/docs/en/configuration.md
+++ b/docs/docs/en/configuration.md
@@ -690,6 +690,7 @@ When using cookie storage, you can configure additional cookie attributes:
 | `httpOnly` | HTTP-only flag. Default: `undefined`          | `boolean`                                             |
 | `sameSite` | SameSite policy.                              | `'strict'` &#124; <br/> `'lax'` &#124; <br/> `'none'` |
 | `expires`  | Expiration date or days. Default: `undefined` | `Date` &#124; <br/> `number`                          |
+| `maxAge`   | Lifetime in seconds from creation. Takes precedence over `expires`. Default: `undefined` | `number`                                              |
 
 #### Locale Storage Attributes
 

--- a/packages/@intlayer/config/src/configFile/configurationSchema.ts
+++ b/packages/@intlayer/config/src/configFile/configurationSchema.ts
@@ -17,6 +17,7 @@ export const cookiesAttributesSchema = z.object({
   httpOnly: z.boolean().optional(),
   sameSite: z.enum(['strict', 'lax', 'none']).optional(),
   expires: z.union([z.date(), z.number()]).optional(),
+  maxAge: z.number().optional(),
 });
 
 export const storageAttributesSchema = z.object({

--- a/packages/@intlayer/config/src/utils/getStorageAttributes.test.ts
+++ b/packages/@intlayer/config/src/utils/getStorageAttributes.test.ts
@@ -72,6 +72,7 @@ describe('getStorageAttributes', () => {
       domain: '.example.com',
       secure: true,
       sameSite: 'strict',
+      maxAge: 60 * 60 * 24 * 365,
     });
 
     expect(result.cookies).toHaveLength(1);
@@ -80,6 +81,7 @@ describe('getStorageAttributes', () => {
     expect(result.cookies[0].attributes.domain).toBe('.example.com');
     expect(result.cookies[0].attributes.secure).toBe(true);
     expect(result.cookies[0].attributes.sameSite).toBe('strict');
+    expect(result.cookies[0].attributes.maxAge).toBe(60 * 60 * 24 * 365);
   });
 
   it('should handle localStorage object with custom name', () => {

--- a/packages/@intlayer/config/src/utils/getStorageAttributes.ts
+++ b/packages/@intlayer/config/src/utils/getStorageAttributes.ts
@@ -42,11 +42,11 @@ type StorageEntry =
 const createCookieEntry = (
   options?: Partial<CookiesAttributes>
 ): CookieEntry => {
-  const { name, path, expires, domain, secure, sameSite, httpOnly } =
+  const { name, path, expires, maxAge, domain, secure, sameSite, httpOnly } =
     options ?? {};
   return {
     name: name ?? COOKIE_NAME,
-    attributes: { path, expires, domain, secure, sameSite, httpOnly },
+    attributes: { path, expires, maxAge, domain, secure, sameSite, httpOnly },
   };
 };
 

--- a/packages/@intlayer/core/src/utils/localeStorage.ts
+++ b/packages/@intlayer/core/src/utils/localeStorage.ts
@@ -44,6 +44,8 @@ export type CookieBuildAttributes = {
   sameSite?: 'strict' | 'lax' | 'none';
   /** Expiry as milliseconds since epoch (Date.getTime()) or number of days */
   expires?: number | undefined;
+  /** Lifetime in seconds from creation. Takes precedence over `expires` */
+  maxAge?: number;
 };
 
 // ============================================================================
@@ -60,11 +62,29 @@ const buildCookieString = (
 
   if (attributes.path) parts.push(`Path=${attributes.path}`);
   if (attributes.domain) parts.push(`Domain=${attributes.domain}`);
-  if (attributes.expires instanceof Date)
+  if (typeof attributes.maxAge === 'number')
+    parts.push(`Max-Age=${Math.floor(attributes.maxAge)}`);
+  else if (attributes.expires instanceof Date)
     parts.push(`Expires=${attributes.expires.toUTCString()}`);
   if (attributes.secure) parts.push('Secure');
   if (attributes.sameSite) parts.push(`SameSite=${attributes.sameSite}`);
   return parts.join('; ');
+};
+
+/**
+ * Resolves the cookie expiry for the Cookie Store API (epoch milliseconds).
+ * `maxAge` takes precedence and is converted to an absolute timestamp, as the
+ * native `maxAge` option of `cookieStore.set()` is not yet supported in all
+ * browsers that support `cookieStore` itself.
+ */
+const getCookieStoreExpires = (
+  attributes: Omit<CookiesAttributes, 'name' | 'type'>
+): number | undefined => {
+  if (typeof attributes.maxAge === 'number')
+    return Date.now() + attributes.maxAge * 1000;
+  return attributes.expires instanceof Date
+    ? attributes.expires.getTime()
+    : attributes.expires;
 };
 
 // ============================================================================
@@ -182,10 +202,7 @@ export const setLocaleInStorageClient = (
         if (options?.setCookieStore) {
           options.setCookieStore(name, locale, {
             ...attributes,
-            expires:
-              attributes.expires instanceof Date
-                ? attributes.expires.getTime()
-                : attributes.expires,
+            expires: getCookieStoreExpires(attributes),
           });
         }
       } catch {
@@ -323,10 +340,7 @@ export const setLocaleInStorageServer = (
         if (options?.setCookieStore) {
           options.setCookieStore(name, locale, {
             ...attributes,
-            expires:
-              attributes.expires instanceof Date
-                ? attributes.expires.getTime()
-                : attributes.expires,
+            expires: getCookieStoreExpires(attributes),
           });
         }
       } catch {
@@ -481,10 +495,7 @@ export const setLocaleInStorage = (
         if (options?.setCookieStore) {
           options.setCookieStore(name, locale, {
             ...attributes,
-            expires:
-              attributes.expires instanceof Date
-                ? attributes.expires.getTime()
-                : attributes.expires,
+            expires: getCookieStoreExpires(attributes),
           });
         }
       } catch {

--- a/packages/@intlayer/types/src/config.ts
+++ b/packages/@intlayer/types/src/config.ts
@@ -155,6 +155,16 @@ export type CookiesAttributes = {
    * Date instance. If omitted, the cookie becomes a session cookie.
    */
   expires?: Date | number | undefined;
+  /**
+   * Cookie max-age to store the locale information
+   *
+   * Default: undefined
+   *
+   * Define the cookie lifetime in seconds from the time of creation
+   * (e.g. `60 * 60 * 24 * 365` for one year). Takes precedence over
+   * `expires` when both are set.
+   */
+  maxAge?: number;
 };
 
 export type StorageAttributes = {


### PR DESCRIPTION
## Motivation

There is currently no reliable way to configure a persistent locale cookie:
the numeric `expires` attribute is treated as an epoch-ms timestamp in the
Cookie Store API path (so `expires: 365` produces a date in January 1970 and
the cookie is deleted immediately), while the `document.cookie` fallback
ignores numeric values entirely and produces a session cookie. A `Date` value
doesn't survive the config JSON serialization either (`instanceof Date` is
always `false` at runtime).

This PR adds a `maxAge` attribute with standard
[`Max-Age`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#max-agenumber)
semantics: lifetime in **seconds from creation**. Unlike an absolute
timestamp, a relative duration survives the config JSON serialization, is
unambiguous in both write paths, and is the natural primitive for a static
config file (an absolute `expires` is frozen at build time).

```ts
// intlayer.config.ts
routing: {
  storage: [
    {
      type: 'cookie',
      path: '/',
      sameSite: 'lax',
      maxAge: 60 * 60 * 24 * 365, // 1 year
    },
  ],
},
```

## Changes

- `@intlayer/types` — add `maxAge?: number` to `CookiesAttributes`
- `@intlayer/config` — accept `maxAge` in the configuration schema and pass it
  through `createCookieEntry`
- `@intlayer/core` —
  - `buildCookieString` emits `Max-Age=` for the `document.cookie` fallback
  - the Cookie Store API path converts `maxAge` to an absolute epoch-ms
    `expires` timestamp via a shared `getCookieStoreExpires` helper. The
    native `maxAge` option of `cookieStore.set()` is only supported in very
    recent browsers (Chrome 145+, Firefox 148+, not Safari) and is silently
    ignored by older ones, while setting both `expires` and `maxAge` throws a
    `TypeError` — converting is the only behavior that works across all
    `cookieStore`-supporting browsers
- `docs/docs/en/configuration.md` — document the new attribute (English only;
  I assume translations are regenerated by your tooling)

`maxAge` takes precedence over `expires` when both are set, consistent with
RFC 6265. Existing `expires` behavior is untouched, so this is purely additive.

## Test plan

- Extended `getStorageAttributes.test.ts` with a `maxAge` pass-through
  assertion — 12/12 passing
- `tsc --noEmit` clean for `@intlayer/config`; no new errors in
  `@intlayer/types` / `@intlayer/core` (the pre-existing
  `verify-icu-format.ts` / `module_augmentation.ts` errors on `main` are
  unrelated)
