### PR TITLE
fix(solid-intlayer): support dynamic dictionaries under SSR and hydration

### DIFF
--- a/examples/tanstack-start-solid-app/intlayer.config.ts
+++ b/examples/tanstack-start-solid-app/intlayer.config.ts
@@ -42,7 +42,7 @@ const config: IntlayerConfig = {
      * - "dynamic": Dynamically imported using Suspense.
      * - "fetch": Fetched dynamically via the live sync API.
      */
-    importMode: 'static',
+    importMode: 'dynamic',
   },
   ai: {
     /**

--- a/packages/solid-intlayer/src/IntlayerNode.test.tsx
+++ b/packages/solid-intlayer/src/IntlayerNode.test.tsx
@@ -50,12 +50,12 @@ describe('renderIntlayerNode', () => {
     const node = renderIntlayerNode({
       children: 'Hello',
       value: 'Hello',
-    }) as any;
+    });
     expect(node.value).toBe('Hello');
   });
 
   it('exposes .value with a raw number', () => {
-    const node = renderIntlayerNode({ children: 42, value: 42 }) as any;
+    const node = renderIntlayerNode({ children: 42, value: 42 });
     expect(node.value).toBe(42);
   });
 
@@ -63,7 +63,7 @@ describe('renderIntlayerNode', () => {
     const node = renderIntlayerNode({
       children: 'Hello',
       value: 'Hello',
-    }) as any;
+    });
     expect(node.toString()).toBe('Hello');
   });
 
@@ -82,6 +82,15 @@ describe('renderIntlayerNode', () => {
     });
     // Solid targets an array; the raw children should be the first item.
     expect(node[0]).toBe('Hello');
+  });
+
+  it('keeps array slice behavior for Solid SSR escaping', () => {
+    const node = renderIntlayerNode({
+      children: 'Hello',
+      value: 'Hello',
+    });
+
+    expect(node.slice()).toEqual(['Hello']);
   });
 });
 

--- a/packages/solid-intlayer/src/IntlayerNode.tsx
+++ b/packages/solid-intlayer/src/IntlayerNode.tsx
@@ -1,6 +1,7 @@
 import type { NodeProps } from '@intlayer/core/interpreter';
 import type { ResolvedEditor } from '@intlayer/types/module_augmentation';
 import type { JSX, ParentProps } from 'solid-js';
+import { isArrayIndexProperty, PROXY_RESERVED_KEYS } from './proxyKeys';
 
 export type IntlayerNode<
   T = NodeProps['children'],
@@ -13,21 +14,22 @@ export type IntlayerNode<
 type RenderIntlayerNodeProps<T> = ParentProps<{
   value: T;
   children: JSX.Element;
-  additionalProps?: { [key: string]: any };
+  additionalProps?: Record<string, unknown>;
 }>;
 
-export const renderIntlayerNode = <
-  T, // Broadened to support arrays, numbers, objects, etc.
->({
+type IntlayerNodeTarget<T> = JSX.Element[] & {
+  value: T;
+  [key: string]: unknown;
+};
+
+export const renderIntlayerNode = <T,>({
   children,
   value,
   additionalProps,
 }: RenderIntlayerNodeProps<T>): IntlayerNode<T> => {
-  // In Solid.js, we must return something that Solid can render.
-  // Arrays are renderable. We can attach metadata to the array object itself.
-  const target = [children] as any;
+  // Solid renders arrays, so wrap children in one and hang metadata off it.
+  const target = [children] as IntlayerNodeTarget<T>;
 
-  // Attach metadata
   target.value = value;
 
   if (additionalProps) {
@@ -36,12 +38,11 @@ export const renderIntlayerNode = <
     }
   }
 
-  // We still use a Proxy to ensure that accessing properties like 'toString'
-  // or others behaves nicely, and to maintain compatibility with the type.
-  // But we target the array directly.
+  // Proxy so `.value`, coercion hooks, etc. resolve to the content while the
+  // target stays a renderable array.
   return new Proxy(target, {
     get(target, prop, receiver) {
-      if (prop === 'value') {
+      if (prop === PROXY_RESERVED_KEYS.value) {
         return value;
       }
 
@@ -50,28 +51,32 @@ export const renderIntlayerNode = <
           if (hint === 'number') return Number(value);
           return value ?? '';
         };
-      if (prop === 'toString') return () => String(value ?? '');
-      if (prop === 'valueOf') return () => value;
+      if (prop === PROXY_RESERVED_KEYS.toString)
+        return () => String(value ?? '');
+      if (prop === PROXY_RESERVED_KEYS.valueOf) return () => value;
 
-      // Delegate native methods/properties to the underlying value.
-      // Guard numeric indices and 'length' so Solid's array renderer keeps
-      // access to the wrapper [children] array intact.
+      // Solid's server renderer calls Array#slice on renderable arrays. Keep
+      // that operation bound to the wrapper [children] array.
+      if (prop === PROXY_RESERVED_KEYS.slice) {
+        return Reflect.get(target, prop, receiver);
+      }
+
       if (
         value !== null &&
         value !== undefined &&
         typeof prop === 'string' &&
-        prop !== 'constructor' &&
-        prop !== 'length' &&
-        !/^\d+$/.test(prop)
+        prop !== PROXY_RESERVED_KEYS.constructor &&
+        prop !== PROXY_RESERVED_KEYS.length &&
+        !isArrayIndexProperty(prop)
       ) {
-        const valObj = Object(value); // Safely boxes primitives (e.g., 50 -> Number object)
+        const valObj = Object(value);
         if (prop in valObj) {
-          const valProp = valObj[prop];
+          const valProp = Reflect.get(valObj, prop);
           return typeof valProp === 'function' ? valProp.bind(value) : valProp;
         }
       }
 
       return Reflect.get(target, prop, receiver);
     },
-  }) as IntlayerNode<T>;
+  }) as unknown as IntlayerNode<T>;
 };

--- a/packages/solid-intlayer/src/client/useDictionaryDynamic.test.ts
+++ b/packages/solid-intlayer/src/client/useDictionaryDynamic.test.ts
@@ -1,0 +1,158 @@
+import type { Dictionary } from '@intlayer/types/dictionary';
+import type { StrictModeLocaleMap } from '@intlayer/types/module_augmentation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  internationalization: { defaultLocale: 'en' },
+}));
+
+const mockSolid = vi.hoisted(() => ({
+  currentLocale: 'en',
+  useContext: vi.fn(() => ({
+    locale: () => mockSolid.currentLocale,
+  })),
+}));
+
+const mockHooks = vi.hoisted(() => ({
+  useDictionary: vi.fn(),
+  useLoadDynamic: vi.fn(),
+}));
+
+vi.mock('@intlayer/config/built', () => ({
+  internationalization: mockConfig.internationalization,
+}));
+
+vi.mock('solid-js', () => ({
+  useContext: mockSolid.useContext,
+}));
+
+vi.mock('./IntlayerProvider', () => ({
+  IntlayerClientContext: {},
+}));
+
+vi.mock('./useDictionary', () => ({
+  useDictionary: mockHooks.useDictionary,
+}));
+
+vi.mock('./useLoadDynamic', () => ({
+  useLoadDynamic: mockHooks.useLoadDynamic,
+}));
+
+const dictionary: Dictionary = {
+  key: 'dictionary',
+  content: { message: 'Loaded' },
+};
+
+const frenchDictionary: Dictionary = {
+  key: 'dictionary',
+  content: { message: 'Chargé' },
+};
+
+describe('useDictionaryDynamic', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockSolid.currentLocale = 'en';
+    mockSolid.useContext.mockClear();
+    mockHooks.useDictionary.mockReset();
+    mockHooks.useLoadDynamic.mockReset();
+    mockHooks.useLoadDynamic.mockReturnValue(dictionary);
+    mockHooks.useDictionary.mockReturnValue({ message: { value: 'Loaded' } });
+  });
+
+  it('passes a reactive cache key and lazy dictionary loader to useLoadDynamic', async () => {
+    const englishDictionaryLoader = vi.fn(() => Promise.resolve(dictionary));
+    const frenchDictionaryLoader = vi.fn(() =>
+      Promise.resolve(frenchDictionary)
+    );
+    const dictionaryLoaders = {
+      en: englishDictionaryLoader,
+      fr: frenchDictionaryLoader,
+    } satisfies StrictModeLocaleMap<() => Promise<typeof dictionary>>;
+    const { useDictionaryDynamic } = await import('./useDictionaryDynamic');
+
+    useDictionaryDynamic(dictionaryLoaders, 'dictionary');
+
+    expect(englishDictionaryLoader).not.toHaveBeenCalled();
+    expect(frenchDictionaryLoader).not.toHaveBeenCalled();
+    expect(mockHooks.useLoadDynamic).toHaveBeenCalledTimes(1);
+    expect(mockHooks.useLoadDynamic).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function)
+    );
+
+    const dictionarySourceAccessor = mockHooks.useLoadDynamic.mock
+      .calls[0]?.[0] as
+      | (() => { cacheKey: string; locale: string })
+      | undefined;
+    const loadDictionary = mockHooks.useLoadDynamic.mock.calls[0]?.[1] as
+      | ((source: { cacheKey: string; locale: string }) => Promise<Dictionary>)
+      | undefined;
+
+    expect(dictionarySourceAccessor?.()).toEqual({
+      cacheKey: 'dictionary.en',
+      locale: 'en',
+    });
+    await expect(
+      loadDictionary?.(
+        dictionarySourceAccessor?.() ?? { cacheKey: '', locale: '' }
+      )
+    ).resolves.toBe(dictionary);
+    expect(englishDictionaryLoader).toHaveBeenCalledTimes(1);
+
+    mockSolid.currentLocale = 'fr';
+
+    expect(dictionarySourceAccessor?.()).toEqual({
+      cacheKey: 'dictionary.fr',
+      locale: 'fr',
+    });
+    await expect(
+      loadDictionary?.(
+        dictionarySourceAccessor?.() ?? { cacheKey: '', locale: '' }
+      )
+    ).resolves.toBe(frenchDictionary);
+    expect(frenchDictionaryLoader).toHaveBeenCalledTimes(1);
+    expect(mockHooks.useDictionary).toHaveBeenCalledWith(dictionary, undefined);
+  });
+
+  it('keeps an explicit locale fixed', async () => {
+    const dictionaryLoader = vi.fn(() => Promise.resolve(dictionary));
+    const dictionaryLoaders = {
+      en: dictionaryLoader,
+    } satisfies StrictModeLocaleMap<() => Promise<typeof dictionary>>;
+    const { useDictionaryDynamic } = await import('./useDictionaryDynamic');
+
+    useDictionaryDynamic(dictionaryLoaders, 'dictionary', 'en');
+
+    const dictionarySourceAccessor = mockHooks.useLoadDynamic.mock
+      .calls[0]?.[0] as
+      | (() => { cacheKey: string; locale: string })
+      | undefined;
+
+    mockSolid.currentLocale = 'fr';
+
+    expect(dictionarySourceAccessor?.()).toEqual({
+      cacheKey: 'dictionary.en',
+      locale: 'en',
+    });
+    expect(mockHooks.useDictionary).toHaveBeenCalledWith(dictionary, 'en');
+  });
+
+  it('rejects with context when a locale loader is missing', async () => {
+    const dictionaryLoaders = {
+      en: vi.fn(() => Promise.resolve(dictionary)),
+    } satisfies StrictModeLocaleMap<() => Promise<typeof dictionary>>;
+    const { useDictionaryDynamic } = await import('./useDictionaryDynamic');
+
+    useDictionaryDynamic(dictionaryLoaders, 'dictionary');
+
+    const loadDictionary = mockHooks.useLoadDynamic.mock.calls[0]?.[1] as
+      | ((source: { cacheKey: string; locale: string }) => Promise<Dictionary>)
+      | undefined;
+
+    await expect(
+      loadDictionary?.({ cacheKey: 'dictionary.fr', locale: 'fr' })
+    ).rejects.toThrow(
+      'No dynamic dictionary loader found for key "dictionary" and locale "fr".'
+    );
+  });
+});

--- a/packages/solid-intlayer/src/client/useDictionaryDynamic.ts
+++ b/packages/solid-intlayer/src/client/useDictionaryDynamic.ts
@@ -10,8 +10,13 @@ import { IntlayerClientContext } from './IntlayerProvider';
 import { useDictionary } from './useDictionary';
 import { useLoadDynamic } from './useLoadDynamic';
 
+type DynamicDictionarySource = {
+  cacheKey: string;
+  locale: LocalesValues;
+};
+
 /**
- * On the server side, Hook that transform a dictionary and return the content
+ * On the client side, Hook that transform a dictionary and return the content
  *
  * If the locale is not provided, it will use the locale from the client context
  */
@@ -25,14 +30,41 @@ export const useDictionaryDynamic = <
 ) => {
   const { locale: currentLocale } = useContext(IntlayerClientContext) ?? {};
   const defaultLocale = internationalization.defaultLocale;
-  const localeTarget = locale ?? currentLocale?.() ?? defaultLocale;
+  const dictionaryLoaders = dictionaryPromise as Partial<
+    Record<LocalesValues, () => Promise<T>>
+  >;
+  const dictionaryKey = String(key);
+  const localeAccessor = () => locale ?? currentLocale?.() ?? defaultLocale;
+  const dictionarySourceAccessor = (): DynamicDictionarySource => {
+    const localeTarget = localeAccessor();
 
-  const dictionary = useLoadDynamic<T>(
-    `${String(key)}.${localeTarget}`,
-    (dictionaryPromise as any)[
-      localeTarget as keyof typeof dictionaryPromise
-    ]?.()
-  ) as T;
+    return {
+      cacheKey: `${dictionaryKey}.${localeTarget}`,
+      locale: localeTarget,
+    };
+  };
+  const loadDictionary = ({
+    locale: localeTarget,
+  }: DynamicDictionarySource) => {
+    const dictionaryLoader = dictionaryLoaders[localeTarget];
 
-  return useDictionary(dictionary, localeTarget);
+    if (!dictionaryLoader) {
+      return Promise.reject(
+        new Error(
+          `No dynamic dictionary loader found for key "${String(key)}" and locale "${localeTarget}".`
+        )
+      );
+    }
+
+    return dictionaryLoader();
+  };
+
+  const dictionary = useLoadDynamic<T, DynamicDictionarySource>(
+    dictionarySourceAccessor,
+    loadDictionary
+  );
+
+  // Keep locale resolution inside useDictionary so the interpreted content
+  // follows the same reactive context as static Solid dictionaries.
+  return useDictionary(dictionary, locale);
 };

--- a/packages/solid-intlayer/src/client/useLoadDynamic.integration.test.tsx
+++ b/packages/solid-intlayer/src/client/useLoadDynamic.integration.test.tsx
@@ -1,0 +1,49 @@
+import { Suspense } from 'solid-js';
+import { render } from 'solid-js/web';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useLoadDynamic } from './useLoadDynamic';
+
+describe('useLoadDynamic integration', () => {
+  let dispose: VoidFunction | undefined;
+
+  afterEach(() => {
+    dispose?.();
+    dispose = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('uses real createResource with Suspense and forwards the resolved value', async () => {
+    let resolveLoader:
+      | ((value: { message: { value: string } }) => void)
+      | undefined;
+    const loader = vi.fn(
+      () =>
+        new Promise<{ message: { value: string } }>((resolve) => {
+          resolveLoader = resolve;
+        })
+    );
+    const App = () => {
+      const content = useLoadDynamic('integration.en', loader);
+
+      return (
+        <Suspense fallback={<span id="fallback">Loading</span>}>
+          <span id="message">{content.message.value}</span>
+        </Suspense>
+      );
+    };
+    const root = document.createElement('div');
+    document.body.append(root);
+
+    dispose = render(() => <App />, root);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(root.querySelector('#fallback')?.textContent).toBe('Loading');
+
+    resolveLoader?.({ message: { value: 'Loaded' } });
+
+    await vi.waitFor(() => {
+      expect(root.querySelector('#message')?.textContent).toBe('Loaded');
+    });
+    expect(root.querySelector('#fallback')).toBeNull();
+  });
+});

--- a/packages/solid-intlayer/src/client/useLoadDynamic.test.ts
+++ b/packages/solid-intlayer/src/client/useLoadDynamic.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ResourceSource<T> = T | (() => T);
+type ResourceFetcher<TSource, TValue> = (
+  source: TSource
+) => TValue | Promise<TValue>;
+
+let resourceValue: unknown;
+let latestResourceSource: (() => unknown) | undefined;
+let latestResourceFetcher: ((source: unknown) => unknown) | undefined;
+
+vi.mock('solid-js', () => ({
+  createResource: <TValue, TSource>(
+    source: ResourceSource<TSource>,
+    fetcher: ResourceFetcher<TSource, TValue>
+  ) => {
+    latestResourceSource = typeof source === 'function' ? source : () => source;
+    latestResourceFetcher = fetcher as (source: unknown) => unknown;
+
+    return [() => resourceValue as TValue | undefined] as const;
+  },
+}));
+
+const importUseLoadDynamic = async () => {
+  vi.resetModules();
+  return await import('./useLoadDynamic');
+};
+
+describe('useLoadDynamic', () => {
+  beforeEach(() => {
+    resourceValue = undefined;
+    latestResourceSource = undefined;
+    latestResourceFetcher = undefined;
+  });
+
+  it('keeps synchronous nested access safe while the resource is pending', async () => {
+    const { useLoadDynamic } = await importUseLoadDynamic();
+    const content = useLoadDynamic<{
+      section: { title: { value: string } };
+      count: number;
+      format: (value: string) => { value: string };
+    }>('dictionary.en', () =>
+      Promise.resolve({
+        section: { title: { value: 'Loaded' } },
+        count: 42,
+        format: (value: string) => ({ value }),
+      })
+    );
+
+    expect(content.section.title.value).toBe('');
+    expect(content.format('message').value).toBe('');
+    expect(Number(content.count)).toBe(0);
+    expect(+content.count).toBe(0);
+    expect((content.section.title as unknown as () => string)()).toBe('');
+    expect(String(content.section.title)).toBe('');
+    expect(latestResourceSource?.()).toBe('dictionary.en');
+  });
+
+  it('forwards property reads and calls once the resource is loaded', async () => {
+    const { useLoadDynamic } = await importUseLoadDynamic();
+
+    resourceValue = {
+      section: { title: { value: 'Loaded' } },
+      count: 42,
+      format: (value: string) => `Formatted ${value}`,
+    };
+
+    const content = useLoadDynamic<{
+      section: { title: { value: string } };
+      count: number;
+      format: (value: string) => string;
+    }>('dictionary.en', () =>
+      Promise.resolve({
+        section: { title: { value: 'Ignored' } },
+        count: 0,
+        format: (value: string) => value,
+      })
+    );
+
+    expect(content.section.title.value).toBe('Loaded');
+    expect(Number(content.count)).toBe(42);
+    expect(+content.count).toBe(42);
+    expect(content.format('message')).toBe('Formatted message');
+  });
+
+  it('caches a pending loader promise by key', async () => {
+    const { useLoadDynamic } = await importUseLoadDynamic();
+    let loadCount = 0;
+    const loadedValue = { key: 'dictionary' };
+
+    useLoadDynamic('dictionary.en', () => {
+      loadCount += 1;
+      return Promise.resolve(loadedValue);
+    });
+
+    const firstLoad = latestResourceFetcher?.('dictionary.en');
+    const secondLoad = latestResourceFetcher?.('dictionary.en');
+
+    expect(loadCount).toBe(1);
+    expect(secondLoad).toBe(firstLoad);
+    await expect(firstLoad).resolves.toBe(loadedValue);
+    expect(latestResourceFetcher?.('dictionary.en')).toBe(loadedValue);
+  });
+
+  it('passes dynamic key changes through the resource fetcher', async () => {
+    const { useLoadDynamic } = await importUseLoadDynamic();
+    let currentKey = 'dictionary.en';
+    const loadKeys: string[] = [];
+
+    useLoadDynamic(
+      () => currentKey,
+      (key) => {
+        loadKeys.push(key);
+        return Promise.resolve({ key });
+      }
+    );
+
+    expect(latestResourceSource?.()).toBe('dictionary.en');
+    await expect(
+      latestResourceFetcher?.(latestResourceSource?.() ?? '')
+    ).resolves.toEqual({ key: 'dictionary.en' });
+
+    currentKey = 'dictionary.fr';
+
+    expect(latestResourceSource?.()).toBe('dictionary.fr');
+    await expect(
+      latestResourceFetcher?.(latestResourceSource?.() ?? '')
+    ).resolves.toEqual({ key: 'dictionary.fr' });
+    expect(loadKeys).toEqual(['dictionary.en', 'dictionary.fr']);
+  });
+
+  it('passes structured sources to loaders and caches by cacheKey', async () => {
+    const { useLoadDynamic } = await importUseLoadDynamic();
+    const source = { cacheKey: 'dictionary.en', locale: 'en' };
+    const loadedValue = { key: 'dictionary' };
+    const loadSources: (typeof source)[] = [];
+
+    useLoadDynamic<typeof loadedValue, typeof source>(
+      source,
+      (resolvedSource) => {
+        loadSources.push(resolvedSource);
+        return Promise.resolve(loadedValue);
+      }
+    );
+
+    const firstLoad = latestResourceFetcher?.(source);
+    const secondLoad = latestResourceFetcher?.({
+      cacheKey: 'dictionary.en',
+      locale: 'en',
+    });
+
+    expect(loadSources).toEqual([source]);
+    expect(secondLoad).toBe(firstLoad);
+    await expect(firstLoad).resolves.toBe(loadedValue);
+  });
+
+  it('does not permanently cache rejected loader promises', async () => {
+    const { useLoadDynamic } = await importUseLoadDynamic();
+    let loadCount = 0;
+
+    useLoadDynamic('dictionary.en', () => {
+      loadCount += 1;
+      return Promise.reject(new Error(`load failed ${loadCount}`));
+    });
+
+    await expect(latestResourceFetcher?.('dictionary.en')).rejects.toThrow(
+      'load failed 1'
+    );
+    await expect(latestResourceFetcher?.('dictionary.en')).rejects.toThrow(
+      'load failed 2'
+    );
+    expect(loadCount).toBe(2);
+  });
+});

--- a/packages/solid-intlayer/src/client/useLoadDynamic.ts
+++ b/packages/solid-intlayer/src/client/useLoadDynamic.ts
@@ -1,34 +1,158 @@
-type Status = 'pending' | 'success' | 'error';
+import { createResource } from 'solid-js';
+import { PROXY_RESERVED_KEYS } from '../proxyKeys';
 
-const createSuspender = <T>(promise: Promise<T>) => {
-  let status: Status = 'pending';
-  let result: T;
-  const suspender = promise.then(
-    (r) => {
-      status = 'success';
-      result = r;
+type DynamicSource = string | { cacheKey: string };
+type DynamicKey<T extends DynamicSource> = T | (() => T);
+// A bare promise cannot be retried after it rejects (already settled); use a
+// function loader when retries matter.
+type DynamicLoader<T, Source extends DynamicSource> =
+  | Promise<T>
+  | ((source: Source) => Promise<T>);
+
+type CacheEntry<T> =
+  | {
+      status: 'pending';
+      promise: Promise<T>;
+    }
+  | {
+      status: 'success';
+      value: T;
+    };
+
+type CallableProxyTarget = (...argumentsList: unknown[]) => unknown;
+
+const NO_PENDING_PRIMITIVE_FALLBACK = Symbol('NO_PENDING_PRIMITIVE_FALLBACK');
+
+/**
+ * Module-level cache to dedupe dynamic imports by key. Solid resources still own
+ * suspense, SSR serialization, hydration, and refetching on source change.
+ */
+const cache = new Map<string, CacheEntry<unknown>>();
+
+const getDynamicSourceCacheKey = (source: DynamicSource): string =>
+  typeof source === 'string' ? source : source.cacheKey;
+
+const readValueAtPath = (
+  value: unknown,
+  path: readonly PropertyKey[]
+): unknown =>
+  path.reduce<unknown>((currentValue, property) => {
+    if (currentValue === null || currentValue === undefined) return undefined;
+
+    return Reflect.get(Object(currentValue), property);
+  }, value);
+
+const resolveDynamicLoader = <T, Source extends DynamicSource>(
+  loader: DynamicLoader<T, Source>,
+  source: Source
+): Promise<T> => (typeof loader === 'function' ? loader(source) : loader);
+
+const loadDynamicValue = <T, Source extends DynamicSource>(
+  source: Source,
+  loader: DynamicLoader<T, Source>
+): T | Promise<T> => {
+  const key = getDynamicSourceCacheKey(source);
+  // Cast is sound only while callers keep one value type per cache key.
+  const cachedEntry = cache.get(key) as CacheEntry<T> | undefined;
+
+  if (cachedEntry?.status === 'success') return cachedEntry.value;
+  if (cachedEntry?.status === 'pending') return cachedEntry.promise;
+
+  const promise = resolveDynamicLoader(loader, source).then(
+    (value) => {
+      cache.set(key, { status: 'success', value });
+      return value;
     },
-    (e) => {
-      status = 'error';
-      result = e as any;
+    (error: unknown) => {
+      cache.delete(key);
+      throw error;
     }
   );
 
-  return {
-    read() {
-      if (status === 'pending') throw suspender;
-      if (status === 'error') throw result;
-      return result!;
-    },
-  };
+  cache.set(key, { status: 'pending', promise });
+
+  return promise;
 };
 
-const cache = new Map<string, ReturnType<typeof createSuspender>>();
+const bindPropertyValue = (value: unknown, propertyValue: unknown): unknown =>
+  typeof propertyValue === 'function'
+    ? propertyValue.bind(value)
+    : propertyValue;
 
-export const useLoadDynamic = <T>(key: string, promise: Promise<T>): T => {
-  if (!cache.has(key)) {
-    cache.set(key, createSuspender(promise));
-  }
+const createPendingPrimitiveFallback = (property: string | symbol): unknown => {
+  if (property === Symbol.toPrimitive) return () => '';
+  if (property === PROXY_RESERVED_KEYS.toString) return () => '';
+  if (property === PROXY_RESERVED_KEYS.valueOf) return () => undefined;
+  if (property === PROXY_RESERVED_KEYS.value) return '';
 
-  return (cache.get(key)! as ReturnType<typeof createSuspender>).read() as T;
+  return NO_PENDING_PRIMITIVE_FALLBACK;
+};
+
+/**
+ * Creates a stable callable proxy that re-reads the Solid resource on each
+ * property access. This keeps synchronous Intlayer access (`content.x.value`)
+ * safe while Solid Suspense owns the actual pending state.
+ */
+const createLoadableProxy = <T>(read: () => T | undefined): T => {
+  const createProxyAtPath = (path: readonly PropertyKey[]): unknown => {
+    const target: CallableProxyTarget = () => undefined;
+
+    return new Proxy(target, {
+      get(_target, property) {
+        if (property === PROXY_RESERVED_KEYS.promiseThen) return undefined;
+
+        const currentValue = readValueAtPath(read(), path);
+
+        if (currentValue !== null && currentValue !== undefined) {
+          if (property === Symbol.toPrimitive) {
+            return () => currentValue;
+          }
+
+          return bindPropertyValue(
+            currentValue,
+            Reflect.get(Object(currentValue), property)
+          );
+        }
+
+        const primitiveFallback = createPendingPrimitiveFallback(property);
+
+        if (primitiveFallback !== NO_PENDING_PRIMITIVE_FALLBACK) {
+          return primitiveFallback;
+        }
+
+        return createProxyAtPath([...path, property]);
+      },
+
+      apply(_target, thisArgument, argumentsList) {
+        const currentValue = readValueAtPath(read(), path);
+
+        if (typeof currentValue !== 'function') {
+          return argumentsList.length === 0 ? '' : createProxyAtPath(path);
+        }
+
+        return Reflect.apply(currentValue, thisArgument, argumentsList);
+      },
+    });
+  };
+
+  return createProxyAtPath([]) as T;
+};
+
+/**
+ * Loads a dynamic value through Solid's resource system so SSR can serialize it
+ * and hydration can read it synchronously. A function source is reactive and
+ * lets Solid refetch when tracked dependencies change. The return is
+ * proxy-backed (not a plain accessor) because Intlayer content is read
+ * synchronously.
+ */
+export const useLoadDynamic = <T, Source extends DynamicSource = string>(
+  key: DynamicKey<Source>,
+  loader: DynamicLoader<T, Source>
+): T => {
+  const keyAccessor = () => (typeof key === 'function' ? key() : key);
+  const [resource] = createResource(keyAccessor, (resolvedSource) =>
+    loadDynamicValue<T, Source>(resolvedSource, loader)
+  );
+
+  return createLoadableProxy(() => resource());
 };

--- a/packages/solid-intlayer/src/proxyKeys.ts
+++ b/packages/solid-intlayer/src/proxyKeys.ts
@@ -1,0 +1,26 @@
+/**
+ * String property keys the Intlayer content proxies special-case instead of
+ * delegating to the wrapped value. `Symbol.toPrimitive` is also reserved but,
+ * being a symbol, is handled inline in each proxy.
+ */
+export const PROXY_RESERVED_KEYS = {
+  // Keep the node reading as an Array rather than the boxed value.
+  constructor: 'constructor',
+  // Solid's SSR renderer reads `length`/indices and calls `slice()` on
+  // renderable arrays; keep these bound to the wrapper `[children]` array.
+  length: 'length',
+  slice: 'slice',
+  // Neutralised so the loadable proxy is never mistaken for a thenable.
+  promiseThen: 'then',
+  // Coercion hooks: resolve to the raw content value, not the array's defaults.
+  toString: 'toString',
+  valueOf: 'valueOf',
+  // Intlayer convention: exposes the raw underlying content.
+  value: 'value',
+} as const satisfies Record<string, string>;
+
+/**
+ * Returns whether a proxy property is a stringified array index.
+ */
+export const isArrayIndexProperty = (property: PropertyKey): boolean =>
+  typeof property === 'string' && /^\d+$/.test(property);


### PR DESCRIPTION
## Summary

`importMode: 'dynamic'` didn't work with Solid SSR. `useLoadDynamic` used a
React-style "throw a promise" suspender that Solid can't serialize or hydrate,
so dynamically imported dictionaries broke under SSR. This rebuilds the loader
on Solid's resource system.

## Problem

- The suspender threw a pending promise (React pattern). Solid SSR neither
  serializes nor replays it, causing hydration mismatches and missing content.
- Intlayer content is read synchronously (`content.x.value`), which a plain
  resource accessor can't serve while pending.

## Solution

- **`useLoadDynamic`** now builds on Solid `createResource`: SSR serializes the
  resolved value and hydration reads it synchronously. The return is
  proxy-backed so synchronous access stays safe while pending; `<Suspense>`
  owns the pending state.
- **`useDictionaryDynamic`** passes a structured `{ cacheKey, locale }` source.
  The loader reads `locale` directly; the cache dedupes by `cacheKey`.
- **`proxyKeys.ts`** centralizes the proxies' reserved keys and
  `isArrayIndexProperty`, including `slice` (Solid's SSR renderer calls
  `Array#slice` on renderable arrays).

## Changes

- `client/useLoadDynamic.ts` — `createResource` + loadable proxy + cache dedupe.
- `client/useDictionaryDynamic.ts` — structured `{ cacheKey, locale }` source.
- `IntlayerNode.tsx` — shared reserved keys; `Reflect.get` for dynamic reads.
- `proxyKeys.ts` — new shared helpers.
- Tests — proxy / cache / coercion / error-retry units, a real
  `createResource` + `<Suspense>` integration test, and `useDictionaryDynamic`
  tests.
- Example — Solid example switched to `importMode: 'dynamic'` to exercise the
  path.

## Testing

- `bun turbo test --filter=solid-intlayer` — 5 files / 23 tests pass.
- `bun turbo build --filter=solid-intlayer` — passes.
- Changed files type-check clean; the package `typecheck` only surfaces
  pre-existing issues unrelated to this PR.
- SSR/hydration verified on `examples/tanstack-start-solid-app`
  (`importMode: 'dynamic'`): 9-page prerender succeeds; Playwright confirms
  hydration, `/fr` locale switch, and no console / page errors.
