### PR TITLE
fix(windows): use POSIX separators for glob and module-id matching

### DIFF
--- a/packages/@intlayer/babel/src/babel-plugin-intlayer-extract.test.ts
+++ b/packages/@intlayer/babel/src/babel-plugin-intlayer-extract.test.ts
@@ -64,6 +64,48 @@ describe('babel-plugin-intlayer-extract', () => {
     expect(output).toContain("import { useIntlayer } from 'react-intlayer';");
   });
 
+  it('should match a back-slash filesList against the POSIX filename', () => {
+    const code = `
+      function MyComponent() {
+        return <div>Hello World</div>;
+      }
+    `;
+
+    // The gate must normalize separators (\ vs /). Back-slashes go on the
+    // filesList side so the raw filename stays a resolvable POSIX path for
+    // extraction under the test OS.
+    const extractedKeys: string[] = [];
+    transform(
+      code,
+      {
+        packageName: 'react-intlayer',
+        filesList: ['\\app\\src\\components\\MyComponent.tsx'],
+        onExtract: (result) => {
+          extractedKeys.push(result.dictionaryKey);
+        },
+      },
+      '/app/src/components/MyComponent.tsx'
+    );
+
+    expect(extractedKeys.length).toBeGreaterThan(0);
+
+    // Sanity check: an unrelated entry still gates the file out.
+    const skippedKeys: string[] = [];
+    transform(
+      code,
+      {
+        packageName: 'react-intlayer',
+        filesList: ['\\app\\src\\components\\Other.tsx'],
+        onExtract: (result) => {
+          skippedKeys.push(result.dictionaryKey);
+        },
+      },
+      '/app/src/components/MyComponent.tsx'
+    );
+
+    expect(skippedKeys.length).toBe(0);
+  });
+
   it('should extract text from function and inject getIntlayer properly', () => {
     const code = `
       function myUtility() {

--- a/packages/@intlayer/babel/src/babel-plugin-intlayer-extract.ts
+++ b/packages/@intlayer/babel/src/babel-plugin-intlayer-extract.ts
@@ -4,6 +4,7 @@ import { parse } from '@babel/parser';
 import type * as BabelTypes from '@babel/types';
 import * as ANSIColors from '@intlayer/config/colors';
 import { colorize, colorizePath, getAppLogger } from '@intlayer/config/logger';
+import { normalizePath } from '@intlayer/config/utils';
 import type { Locale } from '@intlayer/types/allLocales';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { FilePathPattern } from '@intlayer/types/filePathPattern';
@@ -76,7 +77,13 @@ export const intlayerExtractBabelPlugin = (_babel: {
 
           if (!filename) return;
 
-          if (opts.filesList && !opts.filesList.includes(filename)) return;
+          // Compare as POSIX paths (babel filenames use OS separators on Windows).
+          if (
+            opts.filesList &&
+            !opts.filesList.map(normalizePath).includes(normalizePath(filename))
+          ) {
+            return;
+          }
 
           const fileCode: string = state.file.code ?? '';
           if (!fileCode) return;

--- a/packages/@intlayer/babel/src/babel-plugin-intlayer-optimize.ts
+++ b/packages/@intlayer/babel/src/babel-plugin-intlayer-optimize.ts
@@ -281,9 +281,12 @@ export const intlayerOptimizeBabelPlugin = (babel: {
       }
 
       // If filesList is provided, check if current file is included
-      const filename = this.file.opts.filename;
+      const filename = this.file.opts.filename
+        ? normalizePath(this.file.opts.filename)
+        : undefined;
       if (this.opts.filesList && filename) {
-        const isIncluded = this.opts.filesList.includes(filename);
+        const filesList = this.opts.filesList.map(normalizePath);
+        const isIncluded = filesList.includes(filename);
 
         if (!isIncluded) {
           // Force _isIncluded to false to skip processing
@@ -298,13 +301,18 @@ export const intlayerOptimizeBabelPlugin = (babel: {
       Program: {
         enter(programPath, state) {
           // Safe access to filename
-          const filename = state.file.opts.filename;
+          const filename = state.file.opts.filename
+            ? normalizePath(state.file.opts.filename)
+            : undefined;
+          const dictionariesEntryPath = state.opts.dictionariesEntryPath
+            ? normalizePath(state.opts.dictionariesEntryPath)
+            : undefined;
 
           // Check if this is the correct file to transform
 
           if (
             state.opts.replaceDictionaryEntry &&
-            filename === state.opts.dictionariesEntryPath
+            filename === dictionariesEntryPath
           ) {
             state._isDictEntry = true;
 

--- a/packages/@intlayer/chokidar/src/utils/buildComponentFilesList.ts
+++ b/packages/@intlayer/chokidar/src/utils/buildComponentFilesList.ts
@@ -1,5 +1,6 @@
-import { isAbsolute, normalize, relative, resolve, sep } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { TRAVERSE_PATTERN } from '@intlayer/config/defaultValues';
+import { normalizePath } from '@intlayer/config/utils';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import fg from 'fast-glob';
 
@@ -82,7 +83,7 @@ export const buildComponentFilesList = (
   ]
     .filter((pattern) => typeof pattern === 'string')
     .filter((pattern) => !pattern.startsWith('!'))
-    .map((pattern) => normalize(pattern));
+    .map(normalizePath);
 
   // User-supplied negations from traversePattern
   const userExcludes = traversePattern
@@ -104,7 +105,7 @@ export const buildComponentFilesList = (
     ])
   )
     .filter((pattern): pattern is string => typeof pattern === 'string')
-    .map((pattern) => normalize(pattern));
+    .map(normalizePath);
 
   // Separate codeDir entries that live inside node_modules.
   // getDistinctRootDirs would collapse them into the project root, after which

--- a/packages/vite-intlayer/src/IntlayerCompilerPlugin.ts
+++ b/packages/vite-intlayer/src/IntlayerCompilerPlugin.ts
@@ -22,6 +22,7 @@ import {
   type GetConfigurationOptions,
   getConfiguration,
 } from '@intlayer/config/node';
+import { normalizePath } from '@intlayer/config/utils';
 import type { CompilerConfig, IntlayerConfig } from '@intlayer/types/config';
 import type { HmrContext, PluginOption } from 'vite';
 
@@ -142,7 +143,8 @@ export const intlayerCompiler = (
    * Build the list of files to transform based on configuration patterns
    */
   const buildFilesListFn = async (): Promise<void> => {
-    filesList = compilerConfig.filesList;
+    // Normalize to POSIX so comparisons match on Windows.
+    filesList = (compilerConfig.filesList ?? []).map(normalizePath);
   };
 
   /**
@@ -213,8 +215,11 @@ export const intlayerCompiler = (
     server,
     modules,
   }: HmrContext): Promise<void> => {
-    // Check if this is a file we should transform
-    const isTransformableFile = filesList.some((fileEl) => fileEl === file);
+    // Check if this is a file we should transform (compare as POSIX paths).
+    const normalizedFile = normalizePath(file);
+    const isTransformableFile = filesList.some(
+      (fileEl) => fileEl === normalizedFile
+    );
 
     if (isTransformableFile) {
       // Check if this file was recently processed to prevent infinite loops
@@ -343,7 +348,8 @@ export const intlayerCompiler = (
 
     const filename = id;
 
-    if (!filesList.includes(filename)) {
+    // Compare as POSIX paths; filename stays raw for extraction below.
+    if (!filesList.includes(normalizePath(filename))) {
       return undefined;
     }
 

--- a/packages/vite-intlayer/src/intlayerOptimizePlugin.ts
+++ b/packages/vite-intlayer/src/intlayerOptimizePlugin.ts
@@ -583,7 +583,9 @@ export const intlayerOptimize = async (
         transform: async (sourceCode, moduleId) => {
           // Strip query parameters added by Vue/Svelte loaders
           // e.g. "HelloWorld.vue?vue&type=script&setup=true&lang.ts" → "HelloWorld.vue"
-          const sourceFilePath = normalizePath(moduleId.split('?', 1)[0]);
+          const sourceFilePath = normalizePath(
+            moduleId.split('?', 1)[0] ?? moduleId
+          );
 
           if (!SOURCE_FILE_REGEX.test(sourceFilePath)) return null;
           if (!transformableFilesList.includes(sourceFilePath)) return null;

--- a/packages/vite-intlayer/src/intlayerOptimizePlugin.ts
+++ b/packages/vite-intlayer/src/intlayerOptimizePlugin.ts
@@ -23,6 +23,7 @@ import {
   colorizeNumber,
   getAppLogger,
 } from '@intlayer/config/logger';
+import { normalizePath } from '@intlayer/config/utils';
 import { getDictionaries } from '@intlayer/dictionaries-entry';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { Dictionary } from '@intlayer/types/dictionary';
@@ -75,17 +76,18 @@ export const intlayerOptimize = async (
       baseDir,
     } = intlayerConfig.system;
 
-    const dictionariesEntryPath = join(mainDir, 'dictionaries.mjs');
-    const unmergedDictionariesEntryPath = join(
-      mainDir,
-      'unmerged_dictionaries.mjs'
+    const dictionariesEntryPath = normalizePath(
+      join(mainDir, 'dictionaries.mjs')
     );
-    const dynamicDictionariesEntryPath = join(
-      mainDir,
-      'dynamic_dictionaries.mjs'
+    const unmergedDictionariesEntryPath = normalizePath(
+      join(mainDir, 'unmerged_dictionaries.mjs')
+    );
+    const dynamicDictionariesEntryPath = normalizePath(
+      join(mainDir, 'dynamic_dictionaries.mjs')
     );
 
-    const componentFilesList = buildComponentFilesList(intlayerConfig);
+    const componentFilesList =
+      buildComponentFilesList(intlayerConfig).map(normalizePath);
 
     const transformableFilesList = [
       ...componentFilesList,
@@ -581,7 +583,7 @@ export const intlayerOptimize = async (
         transform: async (sourceCode, moduleId) => {
           // Strip query parameters added by Vue/Svelte loaders
           // e.g. "HelloWorld.vue?vue&type=script&setup=true&lang.ts" → "HelloWorld.vue"
-          const sourceFilePath = moduleId.split('?', 1)[0];
+          const sourceFilePath = normalizePath(moduleId.split('?', 1)[0]);
 
           if (!SOURCE_FILE_REGEX.test(sourceFilePath)) return null;
           if (!transformableFilesList.includes(sourceFilePath)) return null;

--- a/packages/vite-intlayer/src/intlayerVueAsyncPlugin.ts
+++ b/packages/vite-intlayer/src/intlayerVueAsyncPlugin.ts
@@ -1,3 +1,4 @@
+import { normalizePath } from '@intlayer/config/utils';
 import type { IntlayerConfig } from '@intlayer/types/config';
 import type { PluginOption } from 'vite';
 
@@ -6,6 +7,7 @@ export const intlayerVueAsyncPlugin = (
   filesList: string[]
 ): PluginOption => {
   const { optimize } = configuration.build;
+  const normalizedFilesList = filesList.map(normalizePath);
   const importMode =
     configuration.build.importMode ?? configuration.dictionary?.importMode;
 
@@ -42,9 +44,9 @@ export const intlayerVueAsyncPlugin = (
        *
        * Prevention for virtual file
        */
-      const filename = id.split('?', 1)[0];
+      const filename = normalizePath(id.split('?', 1)[0] ?? id);
 
-      if (!filesList.includes(filename)) return null;
+      if (!normalizedFilesList.includes(filename)) return null;
 
       // Check if the file actually uses the composable to avoid unnecessary work
       if (!code.includes('useIntlayer')) return null;


### PR DESCRIPTION
## Problem

On Windows the build optimization (dictionary pruning / minification) silently
does nothing: component files are never discovered, and the Vite/Babel
transforms never fire. Everything works on macOS/Linux.

## Root cause

`node:path` emits **backslash** separators on Windows, but two consumers
require **forward slashes**:

1. **fast-glob** — glob patterns must use POSIX separators; a `\` is treated as
   an escape character, so `buildComponentFilesList` matches nothing.
2. **Path equality vs. bundler module ids** — Vite/Rollup always expose module
   ids with `/`. The optimize plugins gate work on `filesList.includes(id)` /
   `filename === dictionariesEntryPath`, which never match when one side carries
   `\`, so the transforms are skipped.

## Fix

Reuse the existing `normalizePath` util from `@intlayer/config/utils`
(`path.replace(/\\/g, '/')`) at the affected sites — no new helper introduced.

- **`@intlayer/chokidar`** `buildComponentFilesList`: normalize glob patterns.
- **`vite-intlayer`** `intlayerOptimizePlugin`: normalize the dictionary entry
  paths, the component file list, and the incoming `moduleId` in `transform`.
- **`@intlayer/babel`** `intlayerOptimizeBabelPlugin`: normalize `filename`,
  `filesList`, and `dictionariesEntryPath` before comparison.

## Notes

- No-op on macOS/Linux (paths are already POSIX), so no behavior change there.
- Reuses the project's existing normalizer rather than adding ad-hoc helpers,
  keeping the canonical path form consistent across the three packages.

## Testing

Verified on Windows 11: `buildComponentFilesList` now returns the expected
component files, and dictionary optimization/minification runs as on POSIX.