### PR TITLE
fix(babel): generalize SSR static dictionary rendering via useDictionaryStaticSsr

### DIFF
--- a/packages/@intlayer/babel/src/babel-plugin-intlayer-optimize.test.ts
+++ b/packages/@intlayer/babel/src/babel-plugin-intlayer-optimize.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import { transformSync } from '@babel/core';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -30,7 +31,9 @@ const transform = (
     unmergedDictionariesEntryPath: '/app/.intlayer/unmerged_dictionaries.mjs',
     replaceDictionaryEntry: false,
     importMode: 'static',
-    filesList: [filename],
+    // Resolve like @babel/core resolves `filename`, so the filesList
+    // inclusion check also matches on Windows.
+    filesList: [resolve(filename)],
     dictionaryModeMap: {},
     ...options,
   };
@@ -144,7 +147,7 @@ describe('babel-plugin-intlayer-optimize', () => {
       );
     });
 
-    it('should leave React SSR dynamic calls unchanged', () => {
+    it('should use a static dictionary during React SSR dynamic imports', () => {
       const code = `
         import { useIntlayer } from "react-intlayer";
         const t = useIntlayer("locale-switcher");
@@ -154,15 +157,18 @@ describe('babel-plugin-intlayer-optimize', () => {
         { importMode: 'dynamic', isServer: true },
         '/app/src/page.tsx'
       );
-      expect(output).not.toContain(
+      expect(output).toContain(
         'import _dicHash from "../.intlayer/dictionaries/locale-switcher.json" with { type: "json" };'
       );
       expect(output).toContain(
-        'const t = useIntlayer(_dicHash_dyn, "locale-switcher");'
+        'import { useDictionary as useIntlayer } from "react-intlayer";'
       );
+      expect(output).not.toContain('_dicHash_dyn');
+      expect(output).not.toContain('useDictionaryDynamic');
+      expect(output).toContain('const t = useIntlayer(_dicHash);');
     });
 
-    it('should leave React SSR dictionary-level dynamic overrides unchanged', () => {
+    it('should use a static dictionary during React SSR dictionary-level dynamic overrides', () => {
       const code = `
         import { useIntlayer } from "react-intlayer";
         const t = useIntlayer("locale-switcher");
@@ -176,15 +182,15 @@ describe('babel-plugin-intlayer-optimize', () => {
         },
         '/app/src/page.tsx'
       );
-      expect(output).not.toContain(
+      expect(output).toContain(
         'import _dicHash from "../.intlayer/dictionaries/locale-switcher.json" with { type: "json" };'
       );
       expect(output).toContain(
-        'import _dicHash_dyn from "../.intlayer/dynamic_dictionaries/locale-switcher.mjs";'
+        'import { useDictionary as useIntlayer } from "react-intlayer";'
       );
-      expect(output).toContain(
-        'const t = useIntlayer(_dicHash_dyn, "locale-switcher");'
-      );
+      expect(output).not.toContain('_dicHash_dyn');
+      expect(output).not.toContain('useDictionaryDynamic');
+      expect(output).toContain('const t = useIntlayer(_dicHash);');
     });
 
     it('should transform fetch imports', () => {
@@ -209,6 +215,32 @@ describe('babel-plugin-intlayer-optimize', () => {
       expect(output).toContain(
         'const t = useIntlayer(_dicHash_fetch, "locale-switcher");'
       );
+    });
+
+    it('should keep dynamic overrides on the dynamic helper during SSR fetch mode', () => {
+      const code = `
+        import { useIntlayer } from "react-intlayer";
+        const t = useIntlayer("locale-switcher");
+      `;
+      const output = transform(
+        code,
+        {
+          importMode: 'fetch',
+          isServer: true,
+          dictionaryModeMap: { 'locale-switcher': 'dynamic' },
+        },
+        '/app/src/page.tsx'
+      );
+      expect(output).toContain(
+        'import _dicHash_dyn from "../.intlayer/dynamic_dictionaries/locale-switcher.mjs";'
+      );
+      expect(output).toContain(
+        'import { useDictionaryDynamic as useIntlayer } from "react-intlayer";'
+      );
+      expect(output).toContain(
+        'const t = useIntlayer(_dicHash_dyn, "locale-switcher");'
+      );
+      expect(output).not.toContain('useDictionary as useIntlayer');
     });
   });
 
@@ -475,9 +507,85 @@ describe('babel-plugin-intlayer-optimize', () => {
       expect(output).toContain(
         'const t = useIntlayer(_dicHash_dyn, "locale-switcher");'
       );
+      expect(output).not.toContain(
+        'import _dicHash from "../.intlayer/dictionaries/locale-switcher.json" with { type: "json" };'
+      );
     });
 
-    it('should use a static dictionary during SSR for packages with an internal fallback', () => {
+    it('should preserve explicit locale in dynamic client imports', () => {
+      const code = `
+        import { useIntlayer } from "solid-intlayer";
+        const t = useIntlayer("locale-switcher", locale);
+      `;
+      const output = transform(
+        code,
+        { importMode: 'dynamic' },
+        '/app/src/page.tsx'
+      );
+      expect(output).toContain(
+        'const t = useIntlayer(_dicHash_dyn, "locale-switcher", locale);'
+      );
+    });
+
+    it('should route mixed fetch and dynamic overrides through the dynamic helper on the client', () => {
+      const code = `
+        import { useIntlayer } from "solid-intlayer";
+        const t = useIntlayer("locale-switcher");
+        const u = useIntlayer("app");
+      `;
+      const output = transform(
+        code,
+        {
+          importMode: 'static',
+          dictionaryModeMap: {
+            app: 'fetch',
+            'locale-switcher': 'dynamic',
+          },
+        },
+        '/app/src/page.tsx'
+      );
+      expect(output).toContain(
+        'import { useDictionaryDynamic as useIntlayer } from "solid-intlayer";'
+      );
+      expect(output).toContain(
+        'const t = useIntlayer(_dicHash_dyn, "locale-switcher");'
+      );
+      expect(output).toContain(
+        'const u = useIntlayer(_dicHash2_fetch, "app");'
+      );
+    });
+
+    it('should keep the dynamic helper on SSR when a fetch override taints the package', () => {
+      const code = `
+        import { useIntlayer } from "solid-intlayer";
+        const t = useIntlayer("locale-switcher");
+        const u = useIntlayer("app");
+      `;
+      const output = transform(
+        code,
+        {
+          importMode: 'dynamic',
+          isServer: true,
+          dictionaryModeMap: { app: 'fetch' },
+        },
+        '/app/src/page.tsx'
+      );
+      expect(output).toContain(
+        'import { useDictionaryDynamic as useIntlayer } from "solid-intlayer";'
+      );
+      expect(output).toContain(
+        'const t = useIntlayer(_dicHash_dyn, "locale-switcher");'
+      );
+      expect(output).toContain(
+        'const u = useIntlayer(_dicHash2_fetch, "app");'
+      );
+      expect(output).not.toContain('solid-intlayer/server');
+      expect(output).not.toContain(
+        'import _dicHash from "../.intlayer/dictionaries/locale-switcher.json" with { type: "json" };'
+      );
+    });
+
+    it('should use a static dictionary during Solid SSR for dynamic imports', () => {
       const code = `
         import { useIntlayer } from "solid-intlayer";
         const t = useIntlayer("locale-switcher");
@@ -494,7 +602,7 @@ describe('babel-plugin-intlayer-optimize', () => {
         'import _dicHash from "../.intlayer/dictionaries/locale-switcher.json" with { type: "json" };'
       );
       expect(output).toContain(
-        'import { useDictionary as useIntlayer } from "solid-intlayer";'
+        'import { useDictionary as useIntlayer } from "solid-intlayer/server";'
       );
       expect(output).not.toContain(
         'import _dicHash_dyn from "../.intlayer/dynamic_dictionaries/locale-switcher.mjs";'
@@ -521,12 +629,33 @@ describe('babel-plugin-intlayer-optimize', () => {
         'import _dicHash from "../.intlayer/dictionaries/locale-switcher.json" with { type: "json" };'
       );
       expect(output).toContain(
-        'import { useDictionary as useIntlayer } from "solid-intlayer";'
+        'import { useDictionary as useIntlayer } from "solid-intlayer/server";'
       );
       expect(output).not.toContain(
         'import _dicHash_dyn from "../.intlayer/dynamic_dictionaries/locale-switcher.mjs";'
       );
       expect(output).not.toContain('useDictionaryDynamic');
+      expect(output).toContain('const t = useIntlayer(_dicHash);');
+    });
+
+    it('should keep other specifiers on the root import when moving useIntlayer to /server', () => {
+      const code = `
+        import { useIntlayer, useLocale } from "solid-intlayer";
+        const t = useIntlayer("locale-switcher");
+        const { locale } = useLocale();
+      `;
+      const output = transform(
+        code,
+        {
+          importMode: 'dynamic',
+          isServer: true,
+        },
+        '/app/src/page.tsx'
+      );
+      expect(output).toContain('import { useLocale } from "solid-intlayer";');
+      expect(output).toContain(
+        'import { useDictionary as useIntlayer } from "solid-intlayer/server";'
+      );
       expect(output).toContain('const t = useIntlayer(_dicHash);');
     });
 

--- a/packages/@intlayer/babel/src/babel-plugin-intlayer-optimize.ts
+++ b/packages/@intlayer/babel/src/babel-plugin-intlayer-optimize.ts
@@ -52,16 +52,19 @@ const DYNAMIC_IMPORT_FUNCTION = {
   useIntlayer: 'useDictionaryDynamic',
 } as const;
 
+/**
+ * Packages whose SSR-static `useDictionary` lives in a `/server` subpath
+ * because it differs from the root one. Solid's reserves one hydration
+ * resource slot so hydration ids stay aligned with the client's
+ * `useDictionaryDynamic`; for other frameworks the root `useDictionary` is
+ * already the correct SSR-static implementation.
+ */
+const SSR_STATIC_IMPORT_SOURCE: Partial<Record<string, string>> = {
+  'solid-intlayer': 'solid-intlayer/server',
+};
+
 type CallerName = (typeof CALLER_LIST)[number];
 type ImportMode = 'static' | 'dynamic' | 'fetch';
-
-/**
- * Packages whose SSR dynamic helper should render synchronously with a static
- * dictionary. Solid streaming SSR can hydrate static output reliably, while
- * its dynamic resource path either suspends during hydration or serializes the
- * full dictionary into HTML.
- */
-const PACKAGE_SSR_DYNAMIC_STATIC_FALLBACK = new Set<string>(['solid-intlayer']);
 
 /**
  * Options for the optimization Babel plugin
@@ -142,8 +145,6 @@ type State = PluginPass & {
   _callerPackageMap?: Map<string, string>;
   /** whether the current file *is* the dictionaries entry file */
   _isDictEntry?: boolean;
-  /** whether dynamic helpers are active for this file */
-  _useDynamicHelpers?: boolean;
   /** whether the current file is included in the filesList */
   _isIncluded?: boolean;
 };
@@ -222,15 +223,41 @@ const isDynamicPackage = (
     packageName as (typeof PACKAGE_LIST_DYNAMIC)[number]
   );
 
-const shouldUseStaticSsrDynamicFallback = (
-  callerPackage: string | undefined,
+/**
+ * Helper family every `useIntlayer`/`getIntlayer` call from one package import
+ * resolves to in the current file. `ssrStatic` is the SSR bundle of a
+ * dynamic-mode file: rewritten to the static `useDictionary` (from the
+ * package's `/server` entry when it has one — see
+ * `SSR_STATIC_IMPORT_SOURCE`) so the server renders static JSON while the
+ * client keeps the dynamic loader.
+ */
+type PackageHelperPlan = 'static' | 'dynamic' | 'ssrStatic';
+
+/**
+ * Decides, once per package import, which helper family applies to this file.
+ * The import rewrite and the per-call rewrite must both derive from this
+ * single decision, or the emitted helper and its argument shape diverge.
+ *
+ * Fetch wins over `ssrStatic`: fetch dictionaries are runtime content, so the
+ * server must keep the real fetch path instead of rendering build-time JSON.
+ */
+const resolveHelperPlan = (
+  packageName: string,
   importMode: ImportMode | undefined,
-  opts: OptimizePluginOptions
-): boolean =>
-  opts.isServer === true &&
-  importMode === 'dynamic' &&
-  callerPackage !== undefined &&
-  PACKAGE_SSR_DYNAMIC_STATIC_FALLBACK.has(callerPackage);
+  isServer: boolean | undefined,
+  packageHasDynamicCall: boolean,
+  packageHasFetchCall: boolean
+): PackageHelperPlan => {
+  if (!isDynamicPackage(packageName)) return 'static';
+
+  if (importMode === 'fetch' || packageHasFetchCall) return 'dynamic';
+
+  if (importMode === 'dynamic' || packageHasDynamicCall) {
+    return isServer === true ? 'ssrStatic' : 'dynamic';
+  }
+
+  return 'static';
+};
 
 /**
  * Babel plugin that transforms Intlayer function calls and auto-imports dictionaries.
@@ -330,7 +357,6 @@ export const intlayerOptimizeBabelPlugin = (babel: {
       this._isIncluded = true;
       this._hasValidImport = false;
       this._isDictEntry = false;
-      this._useDynamicHelpers = false;
 
       // If optimize is false, skip processing entirely
       if (this.opts.optimize === false) {
@@ -466,11 +492,36 @@ export const intlayerOptimizeBabelPlugin = (babel: {
             },
           });
 
+          const getHelperPlan = (packageName: string): PackageHelperPlan =>
+            resolveHelperPlan(
+              packageName,
+              state.opts.importMode,
+              state.opts.isServer,
+              packagesWithDynamicCall.has(packageName),
+              packagesWithFetchCall.has(packageName)
+            );
+
           programPath.traverse({
             ImportDeclaration(path) {
               const src = path.node.source.value;
 
               if (!PACKAGE_LIST.includes(src)) return;
+
+              // Per-import swap, mirrored across bundles — Solid hydration
+              // ids rely on the SSR and client helpers consuming one
+              // resource slot per call alike (see solid-intlayer/server).
+              const helperPlan = getHelperPlan(src);
+              const serverSource =
+                helperPlan === 'ssrStatic'
+                  ? SSR_STATIC_IMPORT_SOURCE[src]
+                  : undefined;
+
+              const helperMap: Record<string, string> =
+                helperPlan === 'dynamic'
+                  ? { ...STATIC_IMPORT_FUNCTION, ...DYNAMIC_IMPORT_FUNCTION }
+                  : { ...STATIC_IMPORT_FUNCTION };
+
+              const serverSpecifiers: BabelTypes.ImportSpecifier[] = [];
 
               for (const spec of path.node.specifiers) {
                 if (!t.isImportSpecifier(spec)) continue;
@@ -481,46 +532,10 @@ export const intlayerOptimizeBabelPlugin = (babel: {
 
                 if (!isCallerName(importedName)) continue;
 
-                const importMode = state.opts.importMode;
-                // Determine whether this import should use the dynamic helpers.
-                const packageHasDynamicCall = packagesWithDynamicCall.has(src);
-                const packageHasFetchCall = packagesWithFetchCall.has(src);
-                // A package import can be rewritten to only one helper. Fetch
-                // overrides therefore keep the dynamic helper for every
-                // useIntlayer call from that package in this file.
-                const shouldUseStaticFallback =
-                  !packageHasFetchCall &&
-                  shouldUseStaticSsrDynamicFallback(
-                    src,
-                    importMode === 'dynamic' || packageHasDynamicCall
-                      ? 'dynamic'
-                      : importMode,
-                    state.opts
-                  );
-                const shouldUseDynamicHelpers =
-                  isDynamicPackage(src) &&
-                  (importMode === 'fetch' ||
-                    packageHasFetchCall ||
-                    ((importMode === 'dynamic' || packageHasDynamicCall) &&
-                      !shouldUseStaticFallback));
-
-                // Remember for later (CallExpression) whether we are using the dynamic helpers
-
-                if (shouldUseDynamicHelpers) {
-                  state._useDynamicHelpers = true;
-                }
-
-                let helperMap: Record<string, string>;
-
-                if (shouldUseDynamicHelpers) {
-                  // Use dynamic helpers for useIntlayer when dynamic mode is enabled
-                  helperMap = {
-                    ...STATIC_IMPORT_FUNCTION,
-                    ...DYNAMIC_IMPORT_FUNCTION,
-                  } as Record<string, string>;
-                } else {
-                  // Use static helpers by default
-                  helperMap = STATIC_IMPORT_FUNCTION as Record<string, string>;
+                if (serverSource && importedName === 'useIntlayer') {
+                  spec.imported = t.identifier('useDictionary');
+                  serverSpecifiers.push(spec);
+                  continue;
                 }
 
                 const newIdentifier = helperMap[importedName];
@@ -530,6 +545,26 @@ export const intlayerOptimizeBabelPlugin = (babel: {
                   // `getIntlayer`), but rewrite the imported identifier so it
                   // points to our helper implementation.
                   spec.imported = t.identifier(newIdentifier);
+                }
+              }
+
+              if (serverSpecifiers.length > 0 && serverSource) {
+                // Move the helper to the /server entry, keeping any other
+                // specifiers (useLocale, …) on the original import.
+                path.insertAfter(
+                  t.importDeclaration(
+                    serverSpecifiers,
+                    t.stringLiteral(serverSource)
+                  )
+                );
+                path.node.specifiers = path.node.specifiers.filter(
+                  (spec) =>
+                    !serverSpecifiers.includes(
+                      spec as BabelTypes.ImportSpecifier
+                    )
+                );
+                if (path.node.specifiers.length === 0) {
+                  path.remove();
                 }
               }
             },
@@ -556,41 +591,23 @@ export const intlayerOptimizeBabelPlugin = (babel: {
               const isUseIntlayer = originalImportedName === 'useIntlayer';
               const dictionaryOverrideMode =
                 state.opts.dictionaryModeMap?.[key];
-              const effectiveImportMode = dictionaryOverrideMode ?? importMode;
-              const packageHasFetchCall =
-                callerPackage !== undefined &&
-                packagesWithFetchCall.has(callerPackage);
-              const usesStaticSsrDynamicFallback =
-                isUseIntlayer &&
-                !packageHasFetchCall &&
-                shouldUseStaticSsrDynamicFallback(
-                  callerPackage,
-                  effectiveImportMode,
-                  state.opts
-                );
-              const useDynamicHelpers =
-                Boolean(state._useDynamicHelpers) &&
-                !usesStaticSsrDynamicFallback;
+              const helperPlan =
+                callerPackage === undefined
+                  ? 'static'
+                  : getHelperPlan(callerPackage);
 
-              // Decide per-call mode: 'static' | 'dynamic' | 'fetch'
+              // Decide per-call mode: 'static' | 'dynamic' | 'fetch'.
               let perCallMode: ImportMode = 'static';
 
-              if (isUseIntlayer && useDynamicHelpers) {
+              if (isUseIntlayer && helperPlan === 'dynamic') {
                 if (dictionaryOverrideMode) {
                   perCallMode = dictionaryOverrideMode;
-                } else if (importMode === 'dynamic') {
-                  perCallMode = 'dynamic';
-                } else if (importMode === 'fetch') {
-                  perCallMode = 'fetch';
+                } else if (importMode === 'dynamic' || importMode === 'fetch') {
+                  perCallMode = importMode;
                 }
-              } else if (
-                isUseIntlayer &&
-                !useDynamicHelpers &&
-                !usesStaticSsrDynamicFallback
-              ) {
-                // If dynamic helpers are NOT active (global mode is static),
-                // we STILL might want to force dynamic/fetch for this specific call
-
+              } else if (isUseIntlayer && helperPlan === 'static') {
+                // The global mode is static, but a per-dictionary override can
+                // still force dynamic/fetch for this specific call.
                 if (
                   dictionaryOverrideMode === 'dynamic' ||
                   dictionaryOverrideMode === 'fetch'

--- a/packages/@intlayer/babel/src/getOptimizePluginOptions.ts
+++ b/packages/@intlayer/babel/src/getOptimizePluginOptions.ts
@@ -20,7 +20,7 @@ type GetOptimizePluginOptionsParams = {
   /**
    * Whether the current transform is for an SSR bundle. When using Babel
    * directly (e.g. in `babel.config.js`), forward the bundler's server flag
-   * here so SSR-specific transforms (such as the Solid static fallback) apply.
+   * here so SSR-specific static dictionary transforms apply.
    */
   isServer?: boolean;
   /**

--- a/packages/solid-intlayer/package.json
+++ b/packages/solid-intlayer/package.json
@@ -58,6 +58,12 @@
       "require": "./dist/cjs/format/index.cjs",
       "import": "./dist/esm/format/index.mjs"
     },
+    "./server": {
+      "types": "./dist/types/server/index.d.ts",
+      "solid": "./dist/esm/server/index.mjs",
+      "require": "./dist/cjs/server/index.cjs",
+      "import": "./dist/esm/server/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/cjs/index.cjs",
@@ -76,6 +82,9 @@
       ],
       "format": [
         "./dist/types/format/index.d.ts"
+      ],
+      "server": [
+        "./dist/types/server/index.d.ts"
       ],
       "package.json": [
         "./package.json"

--- a/packages/solid-intlayer/src/client/useLoadDynamic.ts
+++ b/packages/solid-intlayer/src/client/useLoadDynamic.ts
@@ -150,6 +150,8 @@ export const useLoadDynamic = <T, Source extends DynamicSource = string>(
   loader: DynamicLoader<T, Source>
 ): T => {
   const keyAccessor = () => (typeof key === 'function' ? key() : key);
+  // One resource slot per call — the server entry's useDictionary mirrors it
+  // so Solid hydration ids stay aligned across bundles.
   const [resource] = createResource(keyAccessor, (resolvedSource) =>
     loadDynamicValue<T, Source>(resolvedSource, loader)
   );

--- a/packages/solid-intlayer/src/server/index.ts
+++ b/packages/solid-intlayer/src/server/index.ts
@@ -1,0 +1,1 @@
+export { useDictionary } from './useDictionary';

--- a/packages/solid-intlayer/src/server/useDictionary.test.ts
+++ b/packages/solid-intlayer/src/server/useDictionary.test.ts
@@ -1,0 +1,84 @@
+import type { Dictionary } from '@intlayer/types/dictionary';
+import type { StrictModeLocaleMap } from '@intlayer/types/module_augmentation';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  // Disable the fire-and-forget renderer imports at the top of plugins.tsx so
+  // no module load can settle after the test environment is torn down.
+  process.env['INTLAYER_NODE_TYPE_MARKDOWN'] = 'false';
+  process.env['INTLAYER_NODE_TYPE_HTML'] = 'false';
+});
+
+const mockSolid = vi.hoisted(() => ({
+  createMemo: vi.fn((fn: () => unknown) => fn),
+  createResource: vi.fn(() => [vi.fn()] as const),
+  useContext: vi.fn(() => undefined),
+}));
+
+const mockConfig = vi.hoisted(() => ({
+  editor: { enabled: false },
+  internationalization: { defaultLocale: 'en', locales: ['en'] },
+}));
+
+vi.mock('solid-js', () => ({
+  createMemo: mockSolid.createMemo,
+  createResource: mockSolid.createResource,
+  useContext: mockSolid.useContext,
+  // plugins.tsx lazy-loads the editor ContentSelector at module scope.
+  lazy: () => () => null,
+}));
+
+vi.mock('../client/IntlayerProvider', () => ({
+  IntlayerClientContext: {},
+}));
+
+vi.mock('@intlayer/config/built', () => ({
+  default: mockConfig,
+  editor: mockConfig.editor,
+  internationalization: mockConfig.internationalization,
+}));
+
+const dictionary = {
+  key: 'landing',
+  content: { title: 'Title' },
+} as const satisfies Dictionary;
+
+describe('server useDictionary', () => {
+  it('reserves a Solid resource slot and returns the static dictionary content', async () => {
+    const { useDictionary } = await import('./useDictionary');
+
+    const content = useDictionary(dictionary, 'en');
+
+    expect(mockSolid.createResource).toHaveBeenCalledWith(
+      expect.any(Function),
+      {
+        initialValue: dictionary,
+        ssrLoadFrom: 'initial',
+      }
+    );
+    expect(content.title.value).toBe('Title');
+  });
+
+  it('consumes exactly as many resource slots as the dynamic client helper', async () => {
+    // Solid hydration ids are positional: both helpers must consume the same
+    // number of resource slots per useIntlayer call site.
+    const { useDictionary } = await import('./useDictionary');
+    const { useDictionaryDynamic } = await import(
+      '../client/useDictionaryDynamic'
+    );
+    const dictionaryLoaders = {
+      en: () => Promise.resolve(dictionary),
+    } satisfies StrictModeLocaleMap<() => Promise<typeof dictionary>>;
+
+    mockSolid.createResource.mockClear();
+    useDictionary(dictionary, 'en');
+    const serverResourceCalls = mockSolid.createResource.mock.calls.length;
+
+    mockSolid.createResource.mockClear();
+    useDictionaryDynamic(dictionaryLoaders, 'landing', 'en');
+    const dynamicResourceCalls = mockSolid.createResource.mock.calls.length;
+
+    expect(serverResourceCalls).toBe(1);
+    expect(dynamicResourceCalls).toBe(serverResourceCalls);
+  });
+});

--- a/packages/solid-intlayer/src/server/useDictionary.ts
+++ b/packages/solid-intlayer/src/server/useDictionary.ts
@@ -1,0 +1,35 @@
+import type { Dictionary } from '@intlayer/types/dictionary';
+import type {
+  DeclaredLocales,
+  LocalesValues,
+} from '@intlayer/types/module_augmentation';
+import { createResource } from 'solid-js';
+import { useDictionary as useDictionaryClient } from '../client/useDictionary';
+
+/**
+ * Server-rendering counterpart of `useDictionaryDynamic`, emitted by the
+ * optimizer in the server bundle so dynamic-mode dictionaries render
+ * synchronously from static JSON.
+ *
+ * The discarded `createResource` is load-bearing: Solid assigns hydration
+ * ids from a positional counter shared by resources and element `data-hk`
+ * keys, and the client bundle consumes one resource slot per call (see
+ * `useLoadDynamic`) — without the matching slot here, every subsequent
+ * hydration key shifts and event bindings are silently lost.
+ * `ssrLoadFrom: 'initial'` keeps the dictionary out of the SSR serialization
+ * payload, so it is not shipped twice in the HTML.
+ */
+export const useDictionary = <
+  const T extends Dictionary,
+  const L extends LocalesValues = DeclaredLocales,
+>(
+  dictionary: T,
+  locale?: L
+) => {
+  createResource(() => dictionary, {
+    initialValue: dictionary,
+    ssrLoadFrom: 'initial',
+  });
+
+  return useDictionaryClient(dictionary, locale);
+};

--- a/packages/solid-intlayer/vitest.config.ts
+++ b/packages/solid-intlayer/vitest.config.ts
@@ -2,7 +2,8 @@ import solidPlugin from 'vite-plugin-solid';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [solidPlugin()],
+  // hot: false — solid-refresh's component wrapper breaks partial 'solid-js' mocks
+  plugins: [solidPlugin({ hot: false })],
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
Follow-up to #460 ("the same behavior can be applied for all frameworks"), using the `/server` convention discussed below.

## Problem

Longer testing of `8.12.4-canary.0` on the same app surfaced an issue smoke testing missed: pages hydrate without warnings, but client interactivity is silently lost.

Solid assigns hydration ids from a positional counter shared by resources and element `data-hk` keys. The client compiles `useIntlayer` to `useDictionaryDynamic` (one resource slot per call); #460's server fallback compiles it to `useDictionary` (no slot). Every hydration key after the first call site shifts by one, so event bindings attach to the wrong nodes.

## Fix

On SSR, the optimizer rewrites dynamic-mode `useIntlayer` imports to the static `useDictionary` for **every** framework (`PACKAGE_SSR_DYNAMIC_STATIC_FALLBACK` removed), sourced from the package's `/server` entry when it has one:

- **`solid-intlayer/server`** (new entry) — its `useDictionary` reserves one resource slot via `createResource(..., { ssrLoadFrom: 'initial' })` before rendering the static dictionary. `'initial'` keeps it out of the SSR payload, so the dictionary still isn't shipped twice. A unit test pins the slot parity with `useDictionaryDynamic`.
- **other frameworks** — the root `useDictionary` is already the correct SSR-static implementation, so no new exports. React keeps the client hook (the existing `react-intlayer/server` is the RSC variant — it resolves the locale from the server context, not the provider).

When the import carries other specifiers (`useLocale`, …) they stay on the root import; only `useIntlayer` moves to `/server`.

Import and per-call rewrites are now driven by a single `resolveHelperPlan`, with fetch taking precedence over the SSR-static rewrite: fetch dictionaries are runtime content, so SSR keeps the real fetch path.

## Also fixed

`importMode: 'fetch'` + per-dictionary `dynamic` override on SSR emitted a dynamic helper with a static argument. The unified decision point fixes it; regression test added.

## Behavior change

React/Vue/Svelte/Preact on vite+babel in `dynamic` mode now render SSR statically (client unchanged). `@intlayer/swc` is untouched — leaving it for the update you mentioned; happy to help there too.

## Testing

- `@intlayer/babel`: 223 passed (incl. the specifier-split case); `solid-intlayer`: 25 passed (incl. slot-parity test)
- End-to-end on the same app as #460: no serialized dictionary in HTML, hydration aligned, interactivity restored
- Test-infra: babel tests resolve `filesList` against cwd (Windows); solid tests use `solidPlugin({ hot: false })`