### PR TITLE
fix(design-system): restore max-height strategy for MaxHeightSmoother when minHeight > 0

### DIFF
--- a/packages/@intlayer/design-system/src/components/MaxHeightSmoother/index.tsx
+++ b/packages/@intlayer/design-system/src/components/MaxHeightSmoother/index.tsx
@@ -148,35 +148,81 @@ export const MaxHeightSmoother: FC<MaxHeightSmootherProps> = ({
   isOverable = false,
   isFocusable = false,
   minHeight = 0,
+  style,
   ...props
-}) => (
-  <div
-    aria-hidden={isFocusable ? isHidden : undefined}
-    tabIndex={isFocusable ? 0 : undefined}
-    role={isFocusable ? 'button' : 'none'}
-    className={cn(
-      'group/height-smoother relative grid w-full grid-rows-[0fr] overflow-hidden transition-all duration-700 ease-in-out',
-      typeof isHidden !== 'undefined' &&
-        !isHidden &&
-        'grid-rows-[1fr] overflow-x-auto',
-      isOverable && 'hover:grid-rows-[1fr] hover:overflow-x-auto',
-      isFocusable &&
-        'focus-within:grid-rows-[1fr] focus-within:overflow-x-auto focus:grid-rows-[1fr] focus:overflow-x-auto',
-      className
-    )}
-    {...props}
-  >
+}) => {
+  const hasMinHeight = minHeight > 0;
+
+  /**
+   * True when the component should render visually collapsed.
+   * In uncontrolled hover/focus mode we always start collapsed
+   * so the CSS interaction selectors have something to open.
+   */
+  const isCollapsed =
+    isHidden === true ||
+    (isHidden === undefined && (isOverable || isFocusable));
+
+  return (
     <div
-      style={{
-        minHeight: `${minHeight}px`,
-      }}
+      role={isFocusable ? 'button' : undefined}
+      tabIndex={isFocusable ? 0 : undefined}
+      aria-expanded={
+        isFocusable && isHidden !== undefined ? !isHidden : undefined
+      }
+      style={
+        hasMinHeight
+          ? ({
+              '--mhs-collapsed': `${minHeight}px`,
+              '--mhs-expanded': '3000px',
+              ...style,
+            } as CSSProperties)
+          : style
+      }
       className={cn(
-        isOverable && 'group-hover/height-smoother:visible',
-        isFocusable && 'group-focus/height-smoother:visible',
+        'group/mhs relative w-full',
+
+        // ── Strategy A: grid-template-rows (minHeight === 0) ─────────────────
+        // overflow-hidden lives on the inner wrapper so box-shadows and outlines
+        // on children are not clipped by the outer container.
+        !hasMinHeight && [
+          'grid transition-[grid-template-rows] duration-500 ease-in-out motion-reduce:transition-none',
+          isCollapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]',
+          isOverable && 'hover:grid-rows-[1fr]',
+          isFocusable && 'focus:grid-rows-[1fr] focus-within:grid-rows-[1fr]',
+        ],
+
+        // ── Strategy B: max-height via CSS variables (minHeight > 0) ─────────
+        // `--mhs-collapsed` and `--mhs-expanded` are set via inline style above.
+        // Tailwind owns `max-height` entirely so :hover/:focus-within override freely.
+        hasMinHeight && [
+          'overflow-hidden transition-[max-height] duration-500 ease-in-out motion-reduce:transition-none',
+          isCollapsed
+            ? 'max-h-[var(--mhs-collapsed)]'
+            : 'max-h-[var(--mhs-expanded)]',
+          isOverable && 'hover:max-h-[var(--mhs-expanded)]',
+          isFocusable && 'focus-within:max-h-[var(--mhs-expanded)]',
+        ],
+
         className
       )}
+      {...props}
     >
-      {children}
+      {/*
+       * Inner wrapper:
+       *   Strategy A — `min-h-0` + `overflow-hidden` lets the grid track
+       *                collapse to 0 and clips content during animation.
+       *   Strategy B — `min-h-[var(--mhs-collapsed)]` provides the visible
+       *                floor via the same CSS variable as the container.
+       */}
+      <div
+        className={cn(
+          'overflow-hidden',
+          !hasMinHeight && 'min-h-0',
+          hasMinHeight && 'min-h-[var(--mhs-collapsed)]'
+        )}
+      >
+        {children}
+      </div>
     </div>
-  </div>
-);
+  );
+};


### PR DESCRIPTION
Fixes #294

## What happened

The two-step expand is a regression, not a missing feature. The max-height strategy for `minHeight > 0` landed in 19bb8a28 (credit @TheoStracke), but the editor rework in b2d302de restored the previous grid-rows-only component body while keeping the new JSDoc and Storybook stories. Since then the component has disagreed with its own documentation and tests: the stories assert `--mhs-collapsed` / `--mhs-expanded` CSS variables and `max-h-[var(...)]` classes that the component no longer renders, and the dead-time bug returned to every consumer that sets a preview floor (`ExpandCollapse`, `CommonQuestions`).

## What this PR does

Restores the documented two-strategy implementation:

- **Strategy A** (`minHeight === 0`): `grid-template-rows` transition, unchanged in spirit; `min-h-0` on the inner wrapper so the track can fully collapse.
- **Strategy B** (`minHeight > 0`): animates `max-height` between `--mhs-collapsed` (the minHeight floor) and `--mhs-expanded`, so the expansion starts from the already-visible floor in one continuous motion instead of the silent `0fr -> minHeight` phase followed by the visible jump.

No changes to the JSDoc or the stories - they already describe exactly this behavior.

## Verification

- Every play-function assertion in `maxheightsmoother.stories.tsx` passes against the restored component (Strategy A classes, Strategy B CSS variables and classes, `role`/`tabIndex`/`aria-expanded`).
- Consumer audit: all `isHidden`-only call sites (`Accordion`, `CollapsibleTable`, `DropDown`, `FileTree`, `MobileNavbar`, the dashboard form sections) stay on Strategy A, which remains a grid, so `DropDown`'s `group-hover/dropdown:grid-rows-[1fr]` overrides keep working. `Accordion`'s `role="region"` / `id` / `aria-labelledby` still win through the props spread.

One thing worth your eyes on review: Strategy A now clips overflow on the inner wrapper rather than the container (as in 19bb8a28), so a consumer that overrides overflow on the container via `className` (DropDown passes `overflow-x-visible`) no longer changes the clipping of flowing content. Dropdown panels are absolutely positioned against the container, so they are not clipped by the inner wrapper - but if you prefer the container-level overflow of the current main, that is a two-line adjustment.
