### PR TITLE
feat(website): animate the navbar GitHub star count

### DIFF
--- a/apps/website/src/components/Navbar/GithubStarCount.test.tsx
+++ b/apps/website/src/components/Navbar/GithubStarCount.test.tsx
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GithubStarCount } from './GithubStarCount';
+
+const fixture = vi.hoisted(() => ({
+  stars: 828 as number | null,
+  locale: 'en',
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  getRouteApi: () => ({
+    useLoaderData: () => ({ githubStars: fixture.stars }),
+  }),
+}));
+
+vi.mock('./useRevalidatedGithubStars', () => ({
+  useRevalidatedGithubStars: (stars: number | null) => stars,
+}));
+
+vi.mock('react-intlayer/format', () => ({
+  useNumber: () => (value: number, options: Intl.NumberFormatOptions) =>
+    new Intl.NumberFormat(fixture.locale, options).format(value),
+}));
+
+beforeEach(() => {
+  fixture.stars = 828;
+  fixture.locale = 'en';
+});
+
+describe('GithubStarCount server rendering', () => {
+  it('does not flash the final count or zero before animation starts', () => {
+    const markup = renderToStaticMarkup(<GithubStarCount />);
+
+    expect(markup).toMatch(/class="absolute[^"]*" aria-hidden="true"><\/span>/);
+    expect(markup).toContain('<span class="sr-only">828</span>');
+    expect(markup).toMatch(
+      /class="invisible [^"]*motion-reduce:visible" aria-hidden="true">828<\/span>/
+    );
+  });
+
+  it('renders nothing when the count is unavailable', () => {
+    fixture.stars = null;
+
+    expect(renderToStaticMarkup(<GithubStarCount />)).toBe('');
+  });
+
+  it('treats zero as an available count', () => {
+    fixture.stars = 0;
+
+    expect(renderToStaticMarkup(<GithubStarCount />)).toContain(
+      '<span class="sr-only">0</span>'
+    );
+  });
+
+  it('reserves room for intermediate digits when the target is compact', () => {
+    fixture.stars = 1000;
+    const markup = renderToStaticMarkup(<GithubStarCount />);
+
+    expect(markup).toContain('<span class="sr-only">1K</span>');
+    expect(markup).toMatch(
+      /class="invisible [^"]*" aria-hidden="true">1000<\/span>/
+    );
+  });
+
+  it.each(['en', 'fr', 'ar'])('keeps compact formatting in %s', (locale) => {
+    fixture.stars = 1250;
+    fixture.locale = locale;
+    const formatted = new Intl.NumberFormat(locale, {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    }).format(1250);
+
+    expect(renderToStaticMarkup(<GithubStarCount />)).toContain(
+      `<span class="sr-only">${formatted}</span>`
+    );
+  });
+});

--- a/apps/website/src/components/Navbar/GithubStarCount.tsx
+++ b/apps/website/src/components/Navbar/GithubStarCount.tsx
@@ -1,5 +1,7 @@
 import { getRouteApi } from '@tanstack/react-router';
+import { animate, useReducedMotion } from 'framer-motion';
 import type { FC } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNumber } from 'react-intlayer/format';
 import { useRevalidatedGithubStars } from './useRevalidatedGithubStars';
 
@@ -24,6 +26,39 @@ export const GithubStarCount: FC = () => {
   const stars = useRevalidatedGithubStars(githubStars);
 
   const format = useNumber();
+  const reducedMotion = useReducedMotion();
+  // Keep the number hidden until the first animation frame after hydration.
+  const [displayedStars, setDisplayedStars] = useState<number | null>(null);
+  const currentStars = useRef(0);
+
+  useEffect(() => {
+    if (stars === null) return;
+
+    if (reducedMotion) {
+      currentStars.current = stars;
+      setDisplayedStars(stars);
+      return;
+    }
+
+    let animation: ReturnType<typeof animate> | undefined;
+    // Hydration can block the main thread longer than the animation lasts.
+    // Start its clock on a browser frame, after the effect work has finished.
+    const frame = requestAnimationFrame(() => {
+      animation = animate(currentStars.current, stars, {
+        duration: 1,
+        ease: 'easeOut',
+        onUpdate: (value) => {
+          currentStars.current = value;
+          setDisplayedStars(Math.round(value));
+        },
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      animation?.stop();
+    };
+  }, [stars, reducedMotion]);
 
   if (stars === null) {
     return <></>;
@@ -35,8 +70,29 @@ export const GithubStarCount: FC = () => {
   });
 
   return (
-    <strong className="text-xs tabular-nums leading-none">
-      {formattedStars}
+    <strong className="relative inline-grid text-right text-xs tabular-nums leading-none">
+      {/* Reserve the final label's width; screen readers get only the final count. */}
+      <span
+        className="invisible col-start-1 row-start-1 motion-reduce:visible"
+        aria-hidden="true"
+      >
+        {formattedStars}
+      </span>
+      {/* Intermediate values such as 999 can be wider than a compact target (1K). */}
+      <span className="invisible col-start-1 row-start-1" aria-hidden="true">
+        {format(stars, { useGrouping: false, maximumFractionDigits: 0 })}
+      </span>
+      <span className="sr-only">{formattedStars}</span>
+      <span
+        className="absolute inset-0 motion-reduce:hidden"
+        aria-hidden="true"
+      >
+        {displayedStars !== null &&
+          format(displayedStars, {
+            notation: 'compact',
+            maximumFractionDigits: 1,
+          })}
+      </span>
     </strong>
   );
 };


### PR DESCRIPTION
The navbar GitHub star count now counts up using the existing Framer Motion dependency. The number stays hidden until the first animation frame, with space reserved to prevent movement, and refreshed counts transition from the current value.

Reduced-motion users see the final count immediately. Localized compact formatting, the unavailable-count fallback, and screen-reader access to the final count are preserved.

Closes #509

### Validation

- Seven server-rendering regression tests pass, covering the initial hidden state, null and zero counts, localized formatting, and space for intermediate digits.
- Browser checks pass for count-up, replay, reduced motion, updates during animation, decreasing counts, unmount cleanup, and stable width at the `1K` boundary. Lifecycle checks use React Strict Mode with mocked data in an isolated harness.
- Final production-page checks pass for hydration, reload, and reduced motion.
- Biome and `git diff --check` pass for the changed files.
- Full production build and postbuild completed, including 5,418 prerendered pages. After the final spacing refinement, `DISABLE_OPTIMIZATION=true bun run build` also passed; the supported flag skips repeating the documentation crawl and compression.

### Existing validation failures

The repository-wide CI build passes (49/49 Turbo tasks). The repository-wide CI test command stops in the untouched `@intlayer/design-system` package: five Shiki language assertions fail and the copy-to-clipboard test reports an attempt to assign to a readonly property. This PR changes only `apps/website/src/components/Navbar/*`.

The full website test command reports 202 passing tests and one failed test, across 12 passing and three failing files:

- `missingTranslation.test.ts`: missing required English translations in existing content.
- `src/utils/markdown.test.ts`: empty `formatRegExp` suite.
- `src/components/MessageFormatterPage/formatter.test.ts`: imports `bun:test` but the website test command uses Vitest.

The website TypeScript check reports 35 errors outside the changed counter and its regression tests. The test runner also emits a React CommonJS/module error and a Vite shutdown warning.

The repository's PR guidelines require tests and build to pass before requesting review. These wider failures need resolution or maintainer guidance before marking this ready for review.

### Demo

<img width="132" height="74" alt="Kooha-2026-09-12-16-00-08" src="https://github.com/user-attachments/assets/eea7be30-b439-4024-b76d-a3891d3da337" />
